### PR TITLE
docs(web): add README

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,15 @@
+# web
+
+Next.js 15 static landing page (Tailwind CSS v4, Framer Motion). Built as a static export and served by nginx in production.
+
+## Development
+
+```bash
+npm ci
+npm run dev    # next dev on :3000
+npm run lint
+npm test       # vitest
+npm run build  # static export to ./out
+```
+
+The Docker image is `ghcr.io/diegoheer/realty-alerts/web` — built and pushed by [.github/workflows/web.yml](../../.github/workflows/web.yml). See the repo-level [CLAUDE.md](../../CLAUDE.md) for project-wide conventions.


### PR DESCRIPTION
## Summary

Adds a minimal README for the web landing page.

Doubles as a CI validation PR for the new pipeline (PR #84) — exercises lint + test + build (`pr-<N>` and `sha-<short>` image push) + preview-url on apps/web/.

## Test plan

- [ ] `lint`, `test`, `build` jobs pass
- [ ] `ghcr.io/diegoheer/realty-alerts/web:pr-<N>` and `:sha-<short>` exist in GHCR
- [ ] GitHub Deployment with `https://web-pr-<N>.realty-ai.nl` appears in the PR sidebar (404 expected at the URL until platform-side k8s config exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)