### PR TITLE
docs(api): add README

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,19 @@
+# api
+
+Django 6.0 + Django Ninja backend. Django ORM over PostgreSQL (psycopg3), Gunicorn in production.
+
+## Development
+
+```bash
+uv sync --dev
+uv run python manage.py migrate
+uv run python manage.py runserver  # :8000
+
+uv run ruff check .
+uv run ty check realty_api/ scraping/ tests/
+uv run pytest tests/ -v
+```
+
+Settings split: `realty_api/settings/{base,local,prod,ci}.py` selected via `DJANGO_SETTINGS_MODULE`. See the repo-level [CLAUDE.md](../../CLAUDE.md) for the full Django + Django Ninja conventions.
+
+The Docker image is `ghcr.io/diegoheer/realty-alerts/api` — built and pushed by [.github/workflows/api.yml](../../.github/workflows/api.yml).


### PR DESCRIPTION
## Summary

Adds a minimal README for the api service.

Doubles as a CI validation PR for the new pipeline (PR #84) — exercises lint + test (with Postgres service) + build (`pr-<N>` and `sha-<short>` image push) + preview-url on services/api/.

## Test plan

- [ ] `lint`, `test`, `build` jobs pass
- [ ] `ghcr.io/diegoheer/realty-alerts/api:pr-<N>` and `:sha-<short>` exist in GHCR
- [ ] GitHub Deployment with `https://api-pr-<N>.realty-ai.nl` appears in the PR sidebar (404 expected until platform-side k8s config exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)