### PR TITLE
ci(repo): auto-label api/web PRs with preview

### DIFF
--- a/.github/workflows/auto-label-preview.yml
+++ b/.github/workflows/auto-label-preview.yml
@@ -1,0 +1,21 @@
+name: Auto-label PRs for preview env
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - "services/api/**"
+      - "apps/web/**"
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add preview label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --add-label preview


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-label-preview.yml` that auto-applies the `preview` label to PRs touching `services/api/**` or `apps/web/**`.
- Triggers the realty-ai-platform `realty-alerts-api-preview` / `realty-alerts-web-preview` ApplicationSets which spin up per-PR preview envs at `https://api-pr-N.realty-ai.nl` / `https://web-pr-N.realty-ai.nl`.
- Scoped to `pull_request: opened` to avoid label↔workflow loops; `services/scraper/**` is intentionally excluded (no preview env — no HTTP surface).

## Test plan
- [ ] Open a no-op PR touching `services/api/**` → `preview` label appears within seconds.
- [ ] Confirm platform-side ArgoCD `realty-alerts-api-preview-pr-N` Application appears within ~60s of `docker-build-push` finishing.
- [ ] Open a no-op PR touching `services/scraper/**` → workflow does NOT run, no label applied.
- [ ] Open a no-op PR touching `apps/web/**` → `preview` label applied; `realty-alerts-web-preview-pr-N` reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)