### PR TITLE
test(web): verify gitops production-PR trigger

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -12,4 +12,4 @@ npm test       # vitest
 npm run build  # static export to ./out
 ```
 
-The Docker image is `ghcr.io/diegoheer/realty-alerts/web` — built and pushed by [.github/workflows/web.yml](../../.github/workflows/web.yml). See the repo-level [CLAUDE.md](../../CLAUDE.md) for project-wide conventions.
+The Docker image is `ghcr.io/diegoheer/realty-alerts/web` — built and pushed by [.github/workflows/web.yml](../../.github/workflows/web.yml). On merge to `main`, that workflow opens a `release/web-sha-…` PR on `realty-ai-platform` to promote the new image to production. See the repo-level [CLAUDE.md](../../CLAUDE.md) for project-wide conventions.


### PR DESCRIPTION
## Summary
- No-op README addition under `apps/web/` to validate the end-to-end CI flow.
- On merge to `main`, expect [.github/workflows/web.yml](.github/workflows/web.yml) to open a `release/web-sha-<short>` PR on `realty-ai-platform` via the `gitops-bump-tag` composite action, and to direct-commit a matching staging bump.

## Test plan
- [x] `Web Landing Page CI` passes on this PR (lint + build only — gitops step is gated to `refs/heads/main`).
- [ ] After merge: workflow run completes green.
- [ ] After merge: new `release/web-sha-<short>` PR appears on `DiegoHeer/realty-ai-platform`.
- [ ] After merge: staging kustomization bumped via direct commit on platform `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)