### PR TITLE
test(api): verify gitops production-PR trigger

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -16,4 +16,4 @@ uv run pytest tests/ -v
 
 Settings split: `realty_api/settings/{base,local,prod,ci}.py` selected via `DJANGO_SETTINGS_MODULE`. See the repo-level [CLAUDE.md](../../CLAUDE.md) for the full Django + Django Ninja conventions.
 
-The Docker image is `ghcr.io/diegoheer/realty-alerts/api` — built and pushed by [.github/workflows/api.yml](../../.github/workflows/api.yml).
+The Docker image is `ghcr.io/diegoheer/realty-alerts/api` — built and pushed by [.github/workflows/api.yml](../../.github/workflows/api.yml). On merge to `main`, that workflow opens a `release/api-sha-…` PR on `realty-ai-platform` to promote the new image to production.


### PR DESCRIPTION
## Summary
- No-op README addition under `services/api/` to validate the end-to-end CI flow.
- On merge to `main`, expect [.github/workflows/api.yml](.github/workflows/api.yml) to open a `release/api-sha-<short>` PR on `realty-ai-platform` via the `gitops-bump-tag` composite action, and to direct-commit a matching staging bump.

## Test plan
- [x] `API CI` passes on this PR (lint + test + build only — gitops step is gated to `refs/heads/main`).
- [ ] After merge: workflow run completes green.
- [ ] After merge: new `release/api-sha-<short>` PR appears on `DiegoHeer/realty-ai-platform`.
- [ ] After merge: staging kustomization bumped via direct commit on platform `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)