### PR TITLE
ci(repo): split gitops tag bump into a separate job

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -81,6 +81,8 @@ jobs:
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.docker.outputs.image-tag }}
     permissions:
       contents: read
       packages: write
@@ -102,12 +104,21 @@ jobs:
         with:
           app-name: api
 
+  gitops-bump:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Bump GitOps tags
-        if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/gitops-bump-tag
         with:
           app-name: api
-          image-tag: ${{ steps.docker.outputs.image-tag }}
+          image-tag: ${{ needs.build.outputs.image-tag }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -50,6 +50,8 @@ jobs:
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.docker.outputs.image-tag }}
     permissions:
       contents: read
       packages: write
@@ -64,12 +66,21 @@ jobs:
           context: services/scraper
           image-name: scraper
 
+  gitops-bump:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Bump GitOps tags
-        if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/gitops-bump-tag
         with:
           app-name: scraper
-          image-tag: ${{ steps.docker.outputs.image-tag }}
+          image-tag: ${{ needs.build.outputs.image-tag }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -65,6 +65,8 @@ jobs:
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.docker.outputs.image-tag }}
     permissions:
       contents: read
       packages: write
@@ -86,12 +88,21 @@ jobs:
         with:
           app-name: web
 
+  gitops-bump:
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Bump GitOps tags
-        if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/gitops-bump-tag
         with:
           app-name: web
-          image-tag: ${{ steps.docker.outputs.image-tag }}
+          image-tag: ${{ needs.build.outputs.image-tag }}
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist/
 
 # Claude Code
 .claude/settings.local.json
+.worktrees/
 
 # IDE
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,14 +47,14 @@ repos:
       - id: eslint-web
         name: Lint TS (web)
         language: system
-        entry: bash -c 'cd apps/web && npx --no-install eslint --max-warnings=0 .'
+        entry: bash -c 'cd apps/web && ./node_modules/.bin/eslint --max-warnings=0 .'
         files: ^apps/web/.*\.(ts|tsx|js|jsx|mjs|cjs)$
         pass_filenames: false
         require_serial: true
       - id: eslint-mobile
         name: Lint TS (mobile)
         language: system
-        entry: bash -c 'cd apps/mobile && npx --no-install eslint --max-warnings=0 .'
+        entry: bash -c 'cd apps/mobile && ./node_modules/.bin/eslint --max-warnings=0 .'
         files: ^apps/mobile/.*\.(ts|tsx|js|jsx|mjs|cjs)$
         pass_filenames: false
         require_serial: true


### PR DESCRIPTION
## Summary
- Move the GitOps tag bump out of each service's `build` job into a new `gitops-bump` job that runs on `needs: [build]` with `if: github.ref == 'refs/heads/main'`.
- Trim the new job's permissions to `contents: read` (the GitHub App token handles all writes to the config repo); `packages: write` / `deployments: write` stay where they're actually used (image push, preview URL).
- Build job now exposes `image-tag` as a job output, consumed by the downstream `gitops-bump` job via `needs.build.outputs.image-tag`.
- Applies to `api.yml`, `web.yml`, `scraper.yml`. `mobile.yml` is unaffected (no Docker build, no gitops bump).

## Why
- Surfaces the bump as a first-class status check in the Actions UI instead of hiding it as the last step of `build`.
- Makes the "only on build success" intent explicit at the job graph level rather than implicit in step ordering.
- Least-privilege: the bump job no longer carries write permissions it doesn't need.

The shared `./.github/actions/gitops-bump-tag` composite action is unchanged.

## Test plan
- [ ] On this PR (non-main ref): `lint` → `test` → `build` should run; `gitops-bump` should be **skipped**.
- [ ] After merge to `main`: `lint` → `test` → `build` → `gitops-bump` should run in order; `gitops-bump` produces the staging direct commit and opens the production PR in `DiegoHeer/realty-ai-platform`, identical to today's behavior.
- [ ] Force a build failure on a test branch — `gitops-bump` should be skipped, not attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)