### PR TITLE
ci(gitops): bump path to apps/realty-alerts/<app>/overlays

### DIFF
--- a/.github/actions/gitops-bump-tag/action.yml
+++ b/.github/actions/gitops-bump-tag/action.yml
@@ -3,7 +3,7 @@ description: Bump image tag in realty-ai-platform config repo (staging direct co
 
 inputs:
   app-name:
-    description: The app name (matches the directory under apps/ in the config repo)
+    description: The app name (matches the directory under apps/realty-alerts/ in the config repo)
     required: true
   image-tag:
     description: The new image tag to deploy (e.g. sha-abc1234)
@@ -40,7 +40,7 @@ runs:
       working-directory: _gitops
       run: |
         IMAGE_REGISTRY=$(echo "${{ inputs.image-registry }}" | tr '[:upper:]' '[:lower:]')
-        cd apps/${{ inputs.app-name }}/overlays/staging
+        cd apps/realty-alerts/${{ inputs.app-name }}/overlays/staging
         kustomize edit set image ${IMAGE_REGISTRY}/${{ inputs.app-name }}=${IMAGE_REGISTRY}/${{ inputs.app-name }}:${{ inputs.image-tag }}
 
     - name: Commit and push staging
@@ -54,7 +54,7 @@ runs:
       working-directory: _gitops
       run: |
         IMAGE_REGISTRY=$(echo "${{ inputs.image-registry }}" | tr '[:upper:]' '[:lower:]')
-        cd apps/${{ inputs.app-name }}/overlays/production
+        cd apps/realty-alerts/${{ inputs.app-name }}/overlays/production
         kustomize edit set image ${IMAGE_REGISTRY}/${{ inputs.app-name }}=${IMAGE_REGISTRY}/${{ inputs.app-name }}:${{ inputs.image-tag }}
 
     - name: Create production PR


### PR DESCRIPTION
## Summary
- Update `.github/actions/gitops-bump-tag/action.yml` to `cd apps/realty-alerts/<app>/overlays/<env>` (was `apps/<app>/overlays/<env>`).
- Update the input description to match.

## Why
Companion to **DiegoHeer/realty-ai-platform#51**, which moves `apps/{api,scraper,web}` into a project-scoped `apps/realty-alerts/` parent. This action runs on every push to `main` after a successful image build; if the path here doesn't track the new layout, the bump step fails when it `cd`s into the old (now-missing) directory.

## Merge order
Merge **realty-ai-platform#51 first**, then this PR. The window between them is risky: any image build that lands in the gap will fail the bump step.

## Test plan
- [ ] Confirm realty-ai-platform#51 is merged.
- [ ] Merge this PR.
- [ ] Trigger one of `api.yml` / `web.yml` / `scraper.yml` (push or `workflow_dispatch`) and verify the staging bump commit + production PR land at the new path in the realty-ai-platform repo.