### PR TITLE
fix(api): require CSRF_TRUSTED_ORIGINS in production settings

### DIFF
--- a/services/api/realty_api/env.py
+++ b/services/api/realty_api/env.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     realty_api_key: str = Field(...)
     django_secret_key: str | None = None
     allowed_hosts: str = ""
+    csrf_trusted_origins: str = ""
     log_level: str = "INFO"
     timezone: str = "Europe/Amsterdam"
 

--- a/services/api/realty_api/settings/prod.py
+++ b/services/api/realty_api/settings/prod.py
@@ -19,9 +19,7 @@ if not ALLOWED_HOSTS:
 
 CSRF_TRUSTED_ORIGINS = [o.strip() for o in SETTINGS.csrf_trusted_origins.split(",") if o.strip()]
 if not CSRF_TRUSTED_ORIGINS:
-    raise ImproperlyConfigured(
-        "CSRF_TRUSTED_ORIGINS must be set (comma-separated, scheme included) in production."
-    )
+    raise ImproperlyConfigured("CSRF_TRUSTED_ORIGINS must be set (comma-separated, scheme included) in production.")
 
 # HTTPS / SSL
 USE_X_FORWARDED_HOST = True

--- a/services/api/realty_api/settings/prod.py
+++ b/services/api/realty_api/settings/prod.py
@@ -17,6 +17,12 @@ ALLOWED_HOSTS = [h.strip() for h in SETTINGS.allowed_hosts.split(",") if h.strip
 if not ALLOWED_HOSTS:
     raise ImproperlyConfigured("ALLOWED_HOSTS must be set (comma-separated) in production.")
 
+CSRF_TRUSTED_ORIGINS = [o.strip() for o in SETTINGS.csrf_trusted_origins.split(",") if o.strip()]
+if not CSRF_TRUSTED_ORIGINS:
+    raise ImproperlyConfigured(
+        "CSRF_TRUSTED_ORIGINS must be set (comma-separated, scheme included) in production."
+    )
+
 # HTTPS / SSL
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
## Summary
- Add `csrf_trusted_origins` field to the pydantic Settings model
- Parse `CSRF_TRUSTED_ORIGINS` (comma-separated, scheme-included) in `prod.py`; raise `ImproperlyConfigured` if empty in production
- Fixes Django admin login 403 on staging and production

## Why
Django 6's CSRF middleware rejects the admin login POST because in our cluster (Cloudflare -> cloudflared -> Traefik -> pod) Traefik strips `X-Forwarded-Proto`, so `request.is_secure()` is False and the computed origin (`http://...`) does not match the browser's `Origin: https://...`. Without `CSRF_TRUSTED_ORIGINS` there is no fallback match.

The matching ConfigMap entries live in [DiegoHeer/realty-ai-platform](https://github.com/DiegoHeer/realty-ai-platform). The platform PR must land **before** the next image SHA bump, or pods will fail to start with `ImproperlyConfigured`.

## Test plan
- [x] `uv run pytest` in `services/api` - 19/19 pass
- [x] Verified prod settings load cleanly with the new env var set
- [x] Verified `ImproperlyConfigured` is raised when env var missing
- [ ] Smoke-test `/admin/` login on `api-staging.realty-ai.nl`
- [ ] Smoke-test `/admin/` login on `api.realty-ai.nl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)