### PR TITLE
fix(scraper): set PYTHONPATH so `python -m scraper` resolves in image

### DIFF
--- a/services/scraper/Dockerfile
+++ b/services/scraper/Dockerfile
@@ -8,6 +8,7 @@ RUN uv sync --locked --no-dev --compile-bytecode
 COPY src/ ./src/
 
 ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH=/app/src
 
 # This image deliberately does NOT bundle Playwright browsers.
 # The scraper connects to a remote Playwright server at $BROWSER_URL (ws://...).


### PR DESCRIPTION
## Summary

- Adds `ENV PYTHONPATH=/app/src` to `services/scraper/Dockerfile` so the runtime `CMD ["python", "-m", "scraper"]` can find the `scraper` package.
- Fixes the cluster CronJob crash: `ModuleNotFoundError: No module named scraper`.

## Root cause

The Dockerfile copies `src/` to `/app/src/` but never installs the local project (pyproject.toml has no `[build-system]` block, so `uv sync --locked --no-dev` only installs declared dependencies — not the project itself) and never extends `sys.path`. Tests were unaffected because `[tool.pytest.ini_options] pythonpath = "src"` makes the package importable for pytest only — that setting is irrelevant at runtime.

Setting `PYTHONPATH=/app/src` is the minimal fix and avoids introducing a packaging backend just for the Docker image.

## Test plan

- [x] `docker build -t scraper-test services/scraper`
- [x] `docker run --rm scraper-test` — previously failed with `ModuleNotFoundError: No module named scraper`. Now fails inside `scraper.runner.run()` at `Settings()` validation (missing `website` / `realty_api_key` env vars), proving `python -m scraper` resolved the package.
- [x] `make pre-commit` — all hooks pass
- [x] `make test` — scraper (16), api (19), mobile (18), web (7) all pass

## Known follow-up (not in scope here)

The `gitops-bump` step on `main` recently failed with `error: failed to push some refs to 'https://github.com/DiegoHeer/realty-ai-platform'` (run #24969566205). That is a separate bug in `.github/actions/gitops-bump-tag/action.yml` and is intentionally **not** addressed in this PR — flagging it so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)