### PR TITLE
feat(api): add scraping.dispatch_scrape celery task

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -42,3 +42,28 @@ Watch the worker log:
 ```bash
 docker compose -f docker-compose.dev.yml logs -f celery-worker
 ```
+
+### Scheduling scrapes from the admin
+
+`scraping.dispatch_scrape(website, run_id=None)` POSTs to the in-cluster Argo
+Events webhook (`ARGO_EVENTS_WEBHOOK_URL`) which spawns a one-shot scraper
+`Job`. To run a scrape on a schedule:
+
+1. Open <http://localhost:8000/admin/django_celery_beat/periodictask/> (or the
+   staging/production admin equivalent).
+2. **Add periodic task** → name it `Scrape funda nightly` (or similar) → pick
+   task `scraping.dispatch_scrape` from the dropdown.
+3. Set kwargs:
+   ```json
+   {"website": "funda"}
+   ```
+   (Valid values: `funda`, `pararius`, `vastgoed_nl` — must match the
+   `Website` enum in `scraping/models.py`. `run_id` is optional; the task
+   generates a UUID when missing.)
+4. Pick or create a Crontab schedule (e.g. `0 6 * * *` UTC).
+5. Save. Beat will fire the task at the next matching tick; the worker POSTs
+   to the webhook; Argo Events spawns the scrape Job.
+
+If `ARGO_EVENTS_WEBHOOK_URL` is unset (local dev, preview namespaces), the
+task short-circuits with a warning instead of erroring — useful for running
+Beat locally without a real webhook to call.

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "django-celery-results>=2.5",
     "django-ninja>=1.6",
     "gunicorn>=23",
+    "httpx>=0.28",
     "loguru>=0.7",
     "psycopg[binary]>=3.3",
     "pydantic-settings>=2.9",
@@ -24,6 +25,7 @@ dev = [
     "factory-boy>=3.3",
     "pytest>=8.4",
     "pytest-django>=4.9",
+    "respx>=0.22",
     "ruff>=0.15",
     "ty>=0.0.32",
 ]

--- a/services/api/realty_api/env.py
+++ b/services/api/realty_api/env.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     timezone: str = "Europe/Amsterdam"
     celery_broker_url: str = "redis://localhost:6379/0"
     celery_task_always_eager: bool = False
+    argo_events_webhook_url: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/services/api/realty_api/settings/base.py
+++ b/services/api/realty_api/settings/base.py
@@ -93,3 +93,10 @@ CELERY_TASK_SOFT_TIME_LIMIT = 240
 CELERY_TASK_ALWAYS_EAGER = SETTINGS.celery_task_always_eager
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+
+# --- Argo Events bridge ---
+# The webhook URL the `scraping.dispatch_scrape` Celery task POSTs to
+# in order to spawn a scrape Job via Argo Events. Empty/None lets the
+# task short-circuit (logged warning, no HTTP call) — useful in local
+# dev and preview namespaces that don't run Argo Events.
+ARGO_EVENTS_WEBHOOK_URL = SETTINGS.argo_events_webhook_url

--- a/services/api/realty_api/settings/prod.py
+++ b/services/api/realty_api/settings/prod.py
@@ -26,6 +26,12 @@ if not SETTINGS.celery_broker_url or SETTINGS.celery_broker_url.startswith("redi
         "CELERY_BROKER_URL must be set to a non-localhost redis URL in production.",
     )
 
+if not SETTINGS.argo_events_webhook_url:
+    raise ImproperlyConfigured(
+        "ARGO_EVENTS_WEBHOOK_URL must be set in production "
+        "(e.g. http://scrape-webhook-eventsource-svc.<ns>.svc.cluster.local:12000/scrape).",
+    )
+
 # HTTPS / SSL
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/services/api/scraping/schemas.py
+++ b/services/api/scraping/schemas.py
@@ -50,3 +50,10 @@ class ScrapeResultsIn(Schema):
         if self.finished_at < self.started_at:
             raise ValueError("finished_at must be >= started_at")
         return self
+
+
+class ScrapeDispatchPayload(Schema):
+    """Body posted to the Argo Events webhook to spawn a scrape Job."""
+
+    website: Website
+    run_id: str

--- a/services/api/scraping/tasks.py
+++ b/services/api/scraping/tasks.py
@@ -1,6 +1,53 @@
+import uuid
+
+import httpx
 from celery import shared_task
+from django.conf import settings
+from loguru import logger
+
+from scraping.models import Website
+from scraping.schemas import ScrapeDispatchPayload
 
 
 @shared_task(name="scraping.ping")
 def ping() -> str:
     return "pong"
+
+
+@shared_task(
+    name="scraping.dispatch_scrape",
+    autoretry_for=(httpx.HTTPError,),
+    retry_backoff=True,
+    retry_backoff_max=60,
+    max_retries=3,
+)
+def dispatch_scrape(website: str, run_id: str | None = None) -> str:
+    """POST a scrape dispatch event to the Argo Events webhook.
+
+    Beat fires this task on a schedule defined in Django admin. Argo
+    Events' webhook EventSource turns the POST into an event; the
+    scraper Sensor turns the event into a one-shot K8s Job.
+
+    Returns the run_id (generated if not provided) so callers can
+    correlate with downstream pod logs (`SCRAPE_RUN_ID` env).
+    """
+    payload = ScrapeDispatchPayload(
+        website=Website(website),
+        run_id=run_id or uuid.uuid4().hex,
+    )
+
+    webhook_url = settings.ARGO_EVENTS_WEBHOOK_URL
+    if not webhook_url:
+        logger.warning(
+            "ARGO_EVENTS_WEBHOOK_URL is not set; skipping dispatch for {} (run_id={})",
+            payload.website,
+            payload.run_id,
+        )
+        return payload.run_id
+
+    with httpx.Client(timeout=10.0) as client:
+        response = client.post(webhook_url, json=payload.model_dump(mode="json"))
+        response.raise_for_status()
+
+    logger.info("Dispatched scrape for {} (run_id={})", payload.website, payload.run_id)
+    return payload.run_id

--- a/services/api/tests/test_tasks.py
+++ b/services/api/tests/test_tasks.py
@@ -1,5 +1,58 @@
+import httpx
+import pytest
+import respx
+
+
 def test_ping_returns_pong_under_eager_mode():
     from scraping.tasks import ping
 
     result = ping.delay()
     assert result.get(timeout=1) == "pong"
+
+
+@respx.mock
+def test_dispatch_scrape_posts_payload_and_returns_run_id(settings):
+    from scraping.tasks import dispatch_scrape
+
+    settings.ARGO_EVENTS_WEBHOOK_URL = "http://webhook.test/scrape"
+    route = respx.post("http://webhook.test/scrape").mock(return_value=httpx.Response(200))
+
+    run_id = dispatch_scrape.delay("funda", "run-abc").get(timeout=1)
+
+    assert run_id == "run-abc"
+    assert route.called
+    body = route.calls.last.request.content.decode()
+    assert '"website":"funda"' in body
+    assert '"run_id":"run-abc"' in body
+
+
+@respx.mock
+def test_dispatch_scrape_generates_run_id_when_missing(settings):
+    from scraping.tasks import dispatch_scrape
+
+    settings.ARGO_EVENTS_WEBHOOK_URL = "http://webhook.test/scrape"
+    respx.post("http://webhook.test/scrape").mock(return_value=httpx.Response(200))
+
+    run_id = dispatch_scrape.delay("pararius").get(timeout=1)
+
+    assert run_id and len(run_id) == 32  # uuid4 hex
+
+
+def test_dispatch_scrape_short_circuits_when_url_unset(settings):
+    from scraping.tasks import dispatch_scrape
+
+    settings.ARGO_EVENTS_WEBHOOK_URL = None
+
+    # No respx mock — if the task attempted an HTTP call it would fail.
+    run_id = dispatch_scrape.delay("funda", "run-skip").get(timeout=1)
+
+    assert run_id == "run-skip"
+
+
+def test_dispatch_scrape_rejects_unknown_website(settings):
+    from scraping.tasks import dispatch_scrape
+
+    settings.ARGO_EVENTS_WEBHOOK_URL = "http://webhook.test/scrape"
+
+    with pytest.raises(ValueError):
+        dispatch_scrape.delay("not-a-real-site").get(timeout=1)

--- a/services/api/uv.lock
+++ b/services/api/uv.lock
@@ -24,6 +24,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -64,6 +76,15 @@ wheels = [
 [package.optional-dependencies]
 redis = [
     { name = "kombu", extra = ["redis"] },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -260,6 +281,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -516,6 +583,7 @@ dependencies = [
     { name = "django-celery-results" },
     { name = "django-ninja" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "loguru" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
@@ -529,6 +597,7 @@ dev = [
     { name = "factory-boy" },
     { name = "pytest" },
     { name = "pytest-django" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -542,6 +611,7 @@ requires-dist = [
     { name = "django-celery-results", specifier = ">=2.5" },
     { name = "django-ninja", specifier = ">=1.6" },
     { name = "gunicorn", specifier = ">=23" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3" },
     { name = "pydantic-settings", specifier = ">=2.9" },
@@ -555,6 +625,7 @@ dev = [
     { name = "factory-boy", specifier = ">=3.3" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-django", specifier = ">=4.9" },
+    { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.15" },
     { name = "ty", specifier = ">=0.0.32" },
 ]
@@ -566,6 +637,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR 3 of 4 in the Argo Events bridge work. Adds the API-side Celery task that bridges Django admin's `PeriodicTask` table to the Argo Events webhook from PR realty-ai-platform#82.

The shape after this PR lands:

```
Django admin (PeriodicTask row)
        │
        │ kwargs={"website":"funda"}
        ▼
api-beat ──▶ Redis ──▶ api-worker ──▶ httpx.post(ARGO_EVENTS_WEBHOOK_URL, ...)
                                           │
                                           ▼
                                  EventSource ──▶ EventBus ──▶ Sensor ──▶ Job
```

## Changes

- `services/api/pyproject.toml` — adds `httpx>=0.28` (runtime) and `respx>=0.22` (test). [build commit](../../commit/c9084bb)
- `services/api/realty_api/env.py` — `argo_events_webhook_url: str | None = None` on the pydantic-settings `Settings` model.
- `services/api/realty_api/settings/base.py` — exposes `ARGO_EVENTS_WEBHOOK_URL`.
- `services/api/realty_api/settings/prod.py` — raises `ImproperlyConfigured` if the URL is empty in production, mirroring the existing `CELERY_BROKER_URL` guard.
- `services/api/scraping/schemas.py` — adds `ScrapeDispatchPayload` (Ninja Schema with `website: Website` + `run_id: str`).
- `services/api/scraping/tasks.py` — adds `scraping.dispatch_scrape(website, run_id=None)`.
- `services/api/tests/test_tasks.py` — four respx-mocked tests: payload shape, run_id generation, empty-URL short-circuit, unknown-website rejection.
- `services/api/README.md` — admin how-to subsection.

## Behaviour notes

- Unknown website values raise `ValueError` immediately — no HTTP call.
- Missing `run_id` is auto-generated as `uuid4().hex` so it can be templated into the spawned Job's `SCRAPE_RUN_ID` env (PR #82's Sensor reads it from `body.run_id`).
- `autoretry_for=(httpx.HTTPError,)` with exponential backoff up to 3 retries. After exhausting retries, Beat fires again at the next cron tick.
- When `ARGO_EVENTS_WEBHOOK_URL` is empty (local dev, preview), the task logs a warning and returns the run_id without dispatching. This avoids spurious errors on every Beat tick in environments that don't run Argo Events.
- Production requires the URL — the same `prod.py` `ImproperlyConfigured` pattern used for `CELERY_BROKER_URL`, `DATABASE_URL`, and `REALTY_API_KEY`.

## Why no retry test

`tests/conftest.py` sets `CELERY_TASK_ALWAYS_EAGER=True` for the suite. Eager mode raises `celery.exceptions.Retry` from inside the call instead of transparently retrying, so `autoretry_for` can't be unit-tested without a real broker. `autoretry_for` is documented Celery behaviour; the test that *would* exercise it is the post-merge staging smoke test below.

## Test plan

### Pre-merge
- [x] `cd services/api && uv run pytest tests/ -v` — 29 passed
- [x] `make pre-commit` — all green (ruff + ty across both python services + lint TS for web/mobile)

### Post-merge (after the gitops bump rolls into staging)
- [ ] `kubectl -n realty-alerts-staging exec deploy/api -- python manage.py shell -c "from scraping.tasks import dispatch_scrape; print(dispatch_scrape.delay('funda').get(timeout=10))"` — expect a uuid hex back, and a `scrape-xxxxx` Job to appear in the namespace.
- [ ] Set `ARGO_EVENTS_WEBHOOK_URL` in the staging api configmap to the in-cluster Argo Events URL: `http://scrape-webhook-eventsource-svc.realty-alerts-staging.svc.cluster.local:12000/scrape`. (Done in the next PR or as a small platform follow-up.)
- [ ] Create a one-off `Clocked` `PeriodicTask` in the staging admin pointing at `scraping.dispatch_scrape` with `kwargs={"website":"funda"}` for ~1 minute out, watch `api-beat` send it, watch `api-worker` POST, watch the Sensor spawn a Job.

### Production rollout
- After staging verifies clean, merge the gitops bump to roll the api image to production.
- Set `ARGO_EVENTS_WEBHOOK_URL` in the production api configmap to the production EventSource URL.
- Production admin starts empty; admins enable scrapes by creating `PeriodicTask` rows when ready.

## Follow-ups not in this PR

- Setting `ARGO_EVENTS_WEBHOOK_URL` in the staging/production api configmaps in the platform repo. Small platform-side change; trivial.
- PR 4: deleting the legacy `apps/realty-alerts/scraper/base/cronjob.yaml` after a soak.
- Pre-existing API 500 on `POST /internal/v1/scrape-runs/pararius/results` — separate debug session, unrelated to this PR (funda and vastgoed_nl ingest fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)