### PR TITLE
fix(api,scraper): pararius scrape submission 500 from oversized image_url

### DIFF
--- a/services/api/scraping/schemas.py
+++ b/services/api/scraping/schemas.py
@@ -1,10 +1,15 @@
 from datetime import datetime
-from typing import Self
+from typing import Annotated, Self
 
 from ninja import Schema
-from pydantic import model_validator
+from pydantic import StringConstraints, model_validator
 
 from scraping.models import ListingStatus, ScrapeRunStatus, Website
+
+# Mirrors Listing.image_url = URLField(max_length=500). Reject non-http(s) values
+# (e.g. data: URIs from scraper bugs) at the schema layer so the failure is a
+# 422 from Ninja rather than a Postgres DataError surfacing as a 500.
+ImageUrl = Annotated[str, StringConstraints(max_length=500, pattern=r"^https?://")]
 
 
 class ListingIn(Schema):
@@ -16,7 +21,7 @@ class ListingIn(Schema):
     property_type: str | None = None
     bedrooms: int | None = None
     area_sqm: float | None = None
-    image_url: str | None = None
+    image_url: ImageUrl | None = None
 
 
 class ListingOut(ListingIn):

--- a/services/api/tests/test_internal.py
+++ b/services/api/tests/test_internal.py
@@ -46,20 +46,20 @@ def test_active_runs_lists_only_running(client, api_key_headers):
     assert body[0]["id"] == running.pk
 
 
-def test_submit_results_creates_run_and_listings(client, api_key_headers, scrape_payload, listing_payload):
+@pytest.mark.parametrize("website", list(Website))
+def test_submit_results_creates_run_and_listings(client, api_key_headers, scrape_payload, listing_payload, website):
     payload = scrape_payload(
         listings=[
-            listing_payload("https://example.com/listing/1"),
-            listing_payload("https://example.com/listing/2"),
+            listing_payload("https://example.com/listing/1", website=website.value),
+            listing_payload("https://example.com/listing/2", website=website.value),
         ]
     )
 
-    response = client.post(
-        f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
-    )
+    response = client.post(f"/internal/v1/scrape-runs/{website.value}/results", json=payload, headers=api_key_headers)
 
     assert response.status_code == 200
     body = response.json()
+    assert body["website"] == website.value
     assert body["listings_found"] == 2
     assert body["listings_new"] == 2
     assert body["status"] == ScrapeRunStatus.SUCCESS.value

--- a/services/api/tests/test_internal.py
+++ b/services/api/tests/test_internal.py
@@ -118,6 +118,28 @@ def test_submit_results_rejects_inverted_timestamps(client, api_key_headers, scr
     assert response.status_code == 422
 
 
+@pytest.mark.parametrize(
+    "image_url",
+    [
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'/>",
+        "https://example.com/" + ("x" * 500),
+    ],
+    ids=["data_uri", "over_500_chars"],
+)
+def test_submit_results_rejects_invalid_image_url(client, api_key_headers, scrape_payload, listing_payload, image_url):
+    payload = scrape_payload(
+        listings=[listing_payload("https://example.com/listing/1", image_url=image_url)],
+    )
+
+    response = client.post(
+        f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
+    )
+
+    assert response.status_code == 422
+    assert "image_url" in response.content.decode()
+    assert Listing.objects.count() == 0
+
+
 def test_submit_results_marks_run_failed_when_error_message(client, api_key_headers, scrape_payload):
     payload = scrape_payload(listings=[], error_message="boom")
 

--- a/services/scraper/src/scraper/scrapers/pararius.py
+++ b/services/scraper/src/scraper/scrapers/pararius.py
@@ -58,7 +58,10 @@ class ParariusScraper(BaseScraper):
         price = price_el.get_text().strip() if price_el else ""
 
         image_el = card.select_one("img.picture__image")
-        image_url = str(image_el.get("src", "")) if image_el else None
+        image_src = str(image_el.get("src", "")) if image_el else ""
+        # Pararius lazy-loads thumbnails behind inline SVG data: placeholders;
+        # only accept real http(s) URLs to keep payloads under the API's varchar(500) cap.
+        image_url = image_src if image_src.startswith(("http://", "https://")) else None
 
         return Listing(
             detail_url=detail_url,

--- a/services/scraper/tests/scrapers/test_pararius.py
+++ b/services/scraper/tests/scrapers/test_pararius.py
@@ -14,3 +14,11 @@ def test_scrape_first_page(pararius_scraper):
     assert listings[0].price == "€\xa0535.000 k.k."
     assert listings[0].city == "almere"
     assert listings[0].website == "pararius"
+
+
+def test_image_urls_are_http_or_none(pararius_scraper):
+    listings = pararius_scraper._scrape_page(page_number=1)
+
+    assert listings, "fixture should yield listings"
+    for listing in listings:
+        assert listing.image_url is None or listing.image_url.startswith(("http://", "https://"))


### PR DESCRIPTION
## Summary

- **Root cause:** Pararius lazy-loads listing thumbnails behind ~10kB inline `data:image/svg+xml;utf8,...` placeholders. The scraper shipped them as `image_url`, which violated the API's `Listing.image_url = URLField(max_length=500)` (`varchar(500)` on Postgres). `bulk_create` skips `full_clean()`, so the value reached the DB and Postgres' `value too long for type character varying(500)` surfaced as an uncaught 500 on `POST /internal/v1/scrape-runs/pararius/results`. One bad row aborted the whole batch — funda and vastgoed_nl avoided this because their selectors only ever return real CDN URLs.
- **Hidden by:** every API integration test hardcoded `Website.FUNDA.value`, and the daily cron is pinned to `WEBSITE=funda`. Pararius is now in the dispatch path (PR series #95–#100), so this needs to land before any pararius `PeriodicTask` is enabled.

## Changes

Three atomic commits:

1. `fix(scraper)`: only accept `http(s)://` for pararius `image_url`; everything else (data: URIs, blank src) becomes `None`.
2. `fix(api)`: tighten `ListingIn.image_url` with `Annotated[str, StringConstraints(max_length=500, pattern=r"^https?://")]` so contract violations become a 422 from Ninja instead of a Postgres `DataError` → 500.
3. `test(api)`: parametrise the submit-results happy-path test over every `Website` member, closing the test gap that hid this bug.

## Test plan

- [x] `cd services/scraper && uv run pytest tests/` — 17/17 green
- [x] `cd services/api && uv run pytest tests/` — 33/33 green (including new `test_submit_results_creates_run_and_listings[funda|pararius|vastgoed_nl]` and `test_submit_results_rejects_invalid_image_url[data_uri|over_500_chars]`)
- [x] `make pre-commit` — all Python hooks (ruff lint, ruff format, ty typecheck, toml/yaml/whitespace) pass
- [ ] CI green
- [ ] Post-merge staging smoke: re-run pararius via the Argo Events webhook and confirm the Job submits successfully and the API logs 200/201s with no `DataError`.

## Out of scope

- Real pararius thumbnails (we lose the image until the scraper grows a `data-src`/`srcset` fallback — separate PR).
- No data migration: every prior pararius submission failed wholesale, so no rows with placeholder URIs exist to backfill.