### PR TITLE
build(docker): align dev playwright server with scraper client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,10 @@ repos:
         files: ^apps/mobile/.*\.(ts|tsx|js|jsx|mjs|cjs)$
         pass_filenames: false
         require_serial: true
+      - id: playwright-version-sync
+        name: Playwright client/server version match
+        language: system
+        entry: bash scripts/check-playwright-version.sh
+        files: ^(services/scraper/uv\.lock|docker-compose\.dev\.yml)$
+        pass_filenames: false
+        require_serial: true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,8 +98,8 @@ services:
   # --- Playwright Server (for Funda scraper) ---
   playwright:
     container_name: realty-playwright
-    image: mcr.microsoft.com/playwright:v1.53.0-noble
-    command: npx -y playwright@1.53.0 run-server --port 3000 --host 0.0.0.0
+    image: mcr.microsoft.com/playwright:v1.58.0-noble
+    command: npx -y playwright@1.58.0 run-server --port 3000 --host 0.0.0.0
     ports:
       - 3000:3000
     healthcheck:

--- a/scripts/check-playwright-version.sh
+++ b/scripts/check-playwright-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Asserts that docker-compose.dev.yml's Playwright server pin matches the
+# scraper's locked playwright client. The two negotiate a WS protocol whose
+# shape changes between minor versions, so any skew silently breaks `make dev`
+# scrapes with `BrowserType.connect: WebSocket error: 400 Bad Request`.
+set -euo pipefail
+
+locked=$(awk '/^name = "playwright"$/{getline; gsub(/[^0-9.]/,""); print; exit}' \
+  services/scraper/uv.lock)
+image=$(grep -oE 'mcr\.microsoft\.com/playwright:v[0-9.]+' \
+  docker-compose.dev.yml | head -1 | sed 's/.*v//')
+cmd=$(grep -oE 'playwright@[0-9.]+' docker-compose.dev.yml | head -1 | sed 's/.*@//')
+
+if [[ -z "$locked" || -z "$image" || -z "$cmd" ]]; then
+  echo "playwright-version-sync: failed to parse one of uv.lock or docker-compose.dev.yml" >&2
+  echo "  uv.lock pin:    '${locked}'" >&2
+  echo "  compose image:  '${image}'" >&2
+  echo "  compose cmd:    '${cmd}'" >&2
+  exit 1
+fi
+
+if [[ "$locked" != "$image" || "$locked" != "$cmd" ]]; then
+  cat >&2 <<EOF
+Playwright client/server version skew detected:
+  services/scraper/uv.lock pin:        $locked
+  docker-compose.dev.yml image tag:    $image
+  docker-compose.dev.yml run-server:   $cmd
+
+Update docker-compose.dev.yml so both the image tag and the
+\`playwright@X.Y.Z\` command match $locked.
+EOF
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Bump** `docker-compose.dev.yml`'s Playwright server from `1.53.0` to `1.58.0` to match the scraper's `uv.lock`-pinned playwright client. The two negotiate a WS protocol whose shape changes between minor versions, so any skew silently breaks `make dev` scrapes with a cryptic `BrowserType.connect: WebSocket error: 400 Bad Request`.
- **Guard** Add a pre-commit hook (`scripts/check-playwright-version.sh`) that asserts the lock pin and both compose references (`mcr.microsoft.com/playwright:vX.Y.Z-noble` and `playwright@X.Y.Z`) stay in sync. Fires whenever either `services/scraper/uv.lock` or `docker-compose.dev.yml` changes, so the next bump can't re-skew without surfacing.

Discovered during the PR #103 end-to-end validation: the first scrape against the live pararius site failed with the WS 400 and zero listings persisted. Bumping the compose to a 1.58.0 image cleared it instantly.

## Test plan

- [x] **Guard sad path** — pre-bump compose vs 1.58 lock returned exit 1 with the diagnostic `1.53.0 vs 1.58.0`
- [x] **Guard happy path** — bumped compose vs 1.58 lock returned exit 0, silent
- [x] **`make pre-commit`** — all 13 hooks green, including the new `Playwright client/server version match`
- [x] **Live e2e** — scraper through `realty-playwright:v1.58.0-noble` against pararius.nl returned 90 listings, 44 new, persisted as `success` in `scrape_runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)