### PR TITLE
perf(scraper): lazy-scan BAG parquet to cut peak RSS

### DIFF
--- a/services/scraper/src/scraper/bag.py
+++ b/services/scraper/src/scraper/bag.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Self
+from typing import Self, cast
 
 import polars as pl
 from loguru import logger
@@ -21,7 +21,7 @@ class ParquetBagLookup:
 
     def __init__(self, parquet_path: Path = BAG_DATA_PATH) -> None:
         self._path = parquet_path
-        self._df: pl.DataFrame | None = None
+        self._df: pl.LazyFrame | None = None
 
     def __enter__(self) -> Self:
         return self
@@ -64,12 +64,10 @@ class ParquetBagLookup:
         )
         return None
 
-    def _df_loaded(self) -> pl.DataFrame:
+    def _df_loaded(self) -> pl.LazyFrame:
         if self._df is None:
-            logger.info(f"Loading BAG parquet from {self._path}")
-            self._df = pl.read_parquet(self._path).with_columns(
-                pl.col("postcode").str.to_uppercase().str.replace_all(" ", "")
-            )
+            logger.info(f"Lazy-scanning BAG parquet from {self._path}")
+            self._df = pl.scan_parquet(self._path)
         return self._df
 
     def _find_candidates(
@@ -81,14 +79,16 @@ class ParquetBagLookup:
     ) -> pl.DataFrame:
         df = self._df_loaded()
         if postcode:
-            return df.filter(
+            collected = df.filter(
                 (pl.col("postcode") == _normalise_postcode(postcode)) & (pl.col("huisnummer") == house_number)
-            )
-        return df.filter(
-            (pl.col("straatnaam").str.to_lowercase() == (street or "").lower())
-            & (pl.col("huisnummer") == house_number)
-            & (pl.col("woonplaats").str.to_lowercase() == city.lower())
-        )
+            ).collect()
+        else:
+            collected = df.filter(
+                (pl.col("straatnaam").str.to_lowercase() == (street or "").lower())
+                & (pl.col("huisnummer") == house_number)
+                & (pl.col("woonplaats").str.to_lowercase() == city.lower())
+            ).collect()
+        return cast(pl.DataFrame, collected)
 
     @staticmethod
     def _filter_by_suffix(candidates: pl.DataFrame, suffix: str) -> pl.DataFrame:


### PR DESCRIPTION
## Summary

Switches `ParquetBagLookup` from `pl.read_parquet` (eager full materialisation) to `pl.scan_parquet` (LazyFrame + predicate pushdown). Each `lookup_bag_id` filter + collect pulls only the row groups whose `postcode` stats match the query, materialising 1–3 rows instead of all 9.99M.

## Measurements (against the real BAG parquet)

| | Before (`read_parquet`) | After (`scan_parquet`) |
|---|---|---|
| Peak RSS | ~1851 MiB | ~168 MiB (≈ **11× lower**) |
| First lookup | ~670 ms (load-warmup) | ~6 ms |
| 30 lookups | ~770 ms | ~170 ms |

This drops the scrape Job memory budget back under the original 512 MiB cap. After this merges, [realty-ai-platform#111](https://github.com/DiegoHeer/realty-ai-platform/pull/111) (the temporary 512Mi → 1Gi bump) can be reverted.

## Notes

- Drops the load-time `with_columns` postcode normalisation — the parquet stores postcodes already uppercase + no-space, and keeping the transform would block parquet predicate pushdown. Query-side `_normalise_postcode` continues to handle user input shaped as `"9901 AA"`.
- `_find_candidates` now `.collect()`s the lazy filter into a `pl.DataFrame`; the rest of the helpers (`_filter_by_suffix`, `_filter_by_city`, `_first_id`) are untouched. `cast` is used to satisfy ty's overload on `LazyFrame.collect()`.
- Public API (`lookup_bag_id`, context-manager protocol) unchanged.

## Test plan

- [x] `cd services/scraper && uv run pytest tests/ -v` — 59 passed (no test changes needed; same fixtures, same assertions)
- [x] `uv run ruff check src/ tests/` + `ruff format --check` — clean
- [x] `uv run ty check src/` — clean
- [x] Local script vs the real parquet — peak RSS 168 MiB, lookups 6 ms each
- [ ] Post-merge: trigger one staging scrape; pod completes without OOMKilled at the temporary 1Gi cap
- [ ] Then revert the platform-side memory bump and re-verify under the original 512 MiB cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)