### PR TITLE
fix(scraper): expand BAG match cascade with main-row fallback

### DIFF
--- a/services/scraper/src/scraper/bag.py
+++ b/services/scraper/src/scraper/bag.py
@@ -77,18 +77,47 @@ class ParquetBagLookup:
             return None
         if candidates.height == 1:
             return self._to_match(candidates)
+        return self._disambiguate(candidates, suffix, city, address)
 
+    def _disambiguate(
+        self,
+        candidates: pl.DataFrame,
+        suffix: str | None,
+        city: str,
+        address: str,
+    ) -> BagMatch | None:
         if suffix:
-            disambiguated = self._filter_by_suffix(candidates, suffix)
-            if disambiguated.height == 1:
-                return self._to_match(disambiguated)
+            picked = self._match_by_suffix(candidates, suffix)
+        else:
+            picked = self._match_main_row(candidates)
+        if picked is not None:
+            return picked
 
         by_city = self._filter_by_city(candidates, city)
         if by_city.height == 1:
             return self._to_match(by_city)
 
+        fallback = self._match_main_row(candidates)
+        if fallback is not None:
+            logger.info(f"BAG fallback to building-level match for {address}")
+            return fallback
+
         logger.warning(f"Ambiguous BAG match for {address}: {candidates.height} candidates")
         return None
+
+    def _match_by_suffix(self, candidates: pl.DataFrame, suffix: str) -> BagMatch | None:
+        exact = self._filter_by_suffix(candidates, suffix)
+        if exact.height == 1:
+            return self._to_match(exact)
+        if exact.height == 0:
+            by_digits = self._filter_by_suffix_digits(candidates, suffix)
+            if by_digits.height == 1:
+                return self._to_match(by_digits)
+        return None
+
+    def _match_main_row(self, candidates: pl.DataFrame) -> BagMatch | None:
+        main = self._filter_main_address(candidates)
+        return self._to_match(main) if main.height == 1 else None
 
     def _df_loaded(self) -> pl.LazyFrame:
         if self._df is None:
@@ -124,8 +153,21 @@ class ParquetBagLookup:
         )
 
     @staticmethod
+    def _filter_by_suffix_digits(candidates: pl.DataFrame, suffix: str) -> pl.DataFrame:
+        # Conservative: only fires for purely numeric input so "A302" can't
+        # accidentally collapse onto "V302".
+        s = suffix.strip()
+        if not s.isdigit():
+            return candidates.head(0)
+        return candidates.filter(pl.col("huisnummertoevoeging").str.replace_all(r"\D", "") == s)
+
+    @staticmethod
     def _filter_by_city(candidates: pl.DataFrame, city: str) -> pl.DataFrame:
         return candidates.filter(pl.col("woonplaats").str.to_lowercase() == city.lower())
+
+    @staticmethod
+    def _filter_main_address(candidates: pl.DataFrame) -> pl.DataFrame:
+        return candidates.filter(pl.col("huisletter").is_null() & pl.col("huisnummertoevoeging").is_null())
 
     @staticmethod
     def _to_match(candidates: pl.DataFrame) -> BagMatch:

--- a/services/scraper/tests/test_bag.py
+++ b/services/scraper/tests/test_bag.py
@@ -12,7 +12,8 @@ from scraper.models import Listing
 
 @pytest.fixture
 def loguru_caplog(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
-    handler_id = logger.add(caplog.handler, format="{message}", level="WARNING")
+    handler_id = logger.add(caplog.handler, format="{message}", level="INFO")
+    caplog.set_level("INFO")
     yield caplog
     logger.remove(handler_id)
 
@@ -30,10 +31,48 @@ def bag_parquet(tmp_path: Path) -> Path:
                 "0003200000200001",
                 "0003200000200002",
                 "0003200000300001",
+                # Parkweg-style cluster: 1 main row + V-prefixed unit numbers.
+                "0402200000600001",
+                "0402200000600101",
+                "0402200000600302",
+                "0402200000600521",
+                # No-main-row cluster: only letter/toevoeging suffixes, used to
+                # exercise the truly-ambiguous case where the building-level
+                # fallback can't find a NULL/NULL row.
+                "0003200000700001",
+                "0003200000700002",
             ],
-            "huisnummer": pl.Series([3, 5, 5, 5, 12, 12, 7], dtype=pl.Int32),
-            "huisletter": [None, None, "A", None, None, None, None],
-            "huisnummertoevoeging": [None, None, None, "bis", None, None, None],
+            "huisnummer": pl.Series([3, 5, 5, 5, 12, 12, 7, 2, 2, 2, 2, 20, 20], dtype=pl.Int32),
+            "huisletter": [
+                None,
+                None,
+                "A",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                "A",
+                "B",
+            ],
+            "huisnummertoevoeging": [
+                None,
+                None,
+                None,
+                "bis",
+                None,
+                None,
+                None,
+                None,
+                "V101",
+                "V302",
+                "V521",
+                None,
+                None,
+            ],
             "postcode": [
                 "9901AA",
                 "9901AA",
@@ -42,6 +81,12 @@ def bag_parquet(tmp_path: Path) -> Path:
                 "1011AB",
                 "1011AB",
                 "1234CD",
+                "3221LV",
+                "3221LV",
+                "3221LV",
+                "3221LV",
+                "9901AA",
+                "9901AA",
             ],
             "straatnaam": [
                 "Snelgersmastraat",
@@ -51,6 +96,12 @@ def bag_parquet(tmp_path: Path) -> Path:
                 "Damrak",
                 "Damrak",
                 "Hoofdstraat",
+                "Parkweg",
+                "Parkweg",
+                "Parkweg",
+                "Parkweg",
+                "Snelgersmastraat",
+                "Snelgersmastraat",
             ],
             "woonplaats": [
                 "Appingedam",
@@ -60,6 +111,12 @@ def bag_parquet(tmp_path: Path) -> Path:
                 "Amsterdam",
                 "Haarlem",
                 "Utrecht",
+                "Hellevoetsluis",
+                "Hellevoetsluis",
+                "Hellevoetsluis",
+                "Hellevoetsluis",
+                "Appingedam",
+                "Appingedam",
             ],
         }
     )
@@ -174,19 +231,96 @@ def test_postcode_missing_falls_back_to_street_city(bag_parquet: Path) -> None:
 
 
 def test_ambiguous_returns_none(bag_parquet: Path) -> None:
-    """Multiple matches that suffix and city can't disambiguate."""
+    """Multiple suffixed candidates and no main row to fall back on → None."""
     with ParquetBagLookup(bag_parquet) as bag:
-        # huisnummer=5 at 9901AA has 3 candidates (no suffix, "A", "bis"); suffix doesn't match any
+        # huisnummer=20 at 9901AA has 2 candidates (huisletter A and B) and
+        # no NULL/NULL main row; suffix "X" matches neither.
         assert (
             bag.lookup(
                 street="Snelgersmastraat",
-                house_number=5,
+                house_number=20,
                 suffix="X",
                 postcode="9901 AA",
                 city="Appingedam",
             )
             is None
         )
+
+
+def test_no_suffix_prefers_main_row_among_siblings(bag_parquet: Path) -> None:
+    """Pararius "Neuweg 14" case: no suffix scraped, multiple candidates share
+    postcode and city, but only one is the bare main address."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Snelgersmastraat",
+            house_number=5,
+            suffix=None,
+            postcode="9901 AA",
+            city="Appingedam",
+        )
+    assert _bag_id(match) == "0003200000133986"
+
+
+def test_digit_suffix_matches_v_prefixed_huisnummertoevoeging(bag_parquet: Path) -> None:
+    """Pararius "Parkweg 2 302" case: suffix "302" must match BAG's "V302"."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Parkweg",
+            house_number=2,
+            suffix="302",
+            postcode="3221 LV",
+            city="Hellevoetsluis",
+        )
+    assert _bag_id(match) == "0402200000600302"
+
+
+def test_digit_suffix_does_not_apply_when_input_has_letters(bag_parquet: Path) -> None:
+    """Digit-only normalisation must not pick V302 for an input like "A302"."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Parkweg",
+            house_number=2,
+            suffix="A302",
+            postcode="3221 LV",
+            city="Hellevoetsluis",
+        )
+    assert _bag_id(match) == "0402200000600001"
+
+
+def test_falls_back_to_main_row_for_unmatched_suffix(
+    bag_parquet: Path,
+    loguru_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When suffix is provided but matches no candidate, return the building's
+    bare main row and log at info level so loose matches stay distinguishable."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Snelgersmastraat",
+            house_number=5,
+            suffix="X",
+            postcode="9901 AA",
+            city="Appingedam",
+        )
+    assert _bag_id(match) == "0003200000133986"
+    assert any("BAG fallback to building-level match" in record.message for record in loguru_caplog.records)
+
+
+def test_unmatched_suffix_without_main_row_still_warns(
+    bag_parquet: Path,
+    loguru_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If neither digit normalisation, city, nor a NULL/NULL row resolves the
+    candidate set, the matcher returns None with the existing warning."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Snelgersmastraat",
+            house_number=20,
+            suffix="X",
+            postcode="9901 AA",
+            city="Appingedam",
+        )
+    assert match is None
+    assert any("Ambiguous BAG match" in record.message for record in loguru_caplog.records)
 
 
 def test_close_clears_cached_frame(bag_parquet: Path) -> None:


### PR DESCRIPTION
## Summary
- Smoke-testing the scraper showed many freshly-scraped listings ending up with `bag_id=None` and an `Ambiguous BAG match` warning. Two real Pararius cases drove this fix: **Neuweg 14 1211LW** (three siblings — main, A, B — no scraped suffix, all in Hilversum so neither suffix nor city collapses the candidate set) and **Parkweg 2 302** at 3221LV (title parses suffix `"302"` but BAG stores the unit as `"V302"`, so the exact uppercase compare misses it).
- The matcher in `services/scraper/src/scraper/bag.py` now runs a small cascade after the existing exact path: (a) when the input has no suffix and exactly one candidate has both `huisletter` and `huisnummertoevoeging` NULL, that main row wins; (b) when the input suffix is purely numeric and the exact suffix filter returns 0 hits, candidates are retried against digit-only forms of `huisnummertoevoeging` so `"302"` matches `"V302"` while `"A302"` still cannot; (c) after the city tiebreaker, if the set hasn't collapsed, the matcher falls back to the building's `(NULL, NULL)` main row at `info` log level so loose matches stay distinguishable from exact ones. It still returns `None` with the existing warning when no main row exists either.
- `lookup()` was split into `_disambiguate` / `_match_by_suffix` / `_match_main_row` to keep cyclomatic complexity below ruff's threshold; behaviour change and refactor are intentionally bundled because the helpers exist to express the cascade.

## Test plan
- [x] `cd services/scraper && uv run pytest tests/` — 73 passed (5 new BAG tests + the existing `test_ambiguous_returns_none` repointed at a no-main-row cluster).
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run ty check src` — clean.
- [ ] End-to-end scraper smoke: previous `Ambiguous BAG match for 1211LW Neuweg 14 …` and `Ambiguous BAG match for 3221LV Parkweg 2-302 …` should be gone; some prior failures should now show as `BAG fallback to building-level match for …` info logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)