### PR TITLE
chore(repo): pin ruff vscode line length to 120

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,8 @@
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
 
+    "ruff.lineLength": 120,
+
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,


### PR DESCRIPTION
## Summary
- Add `"ruff.lineLength": 120` to `.vscode/settings.json` so the Ruff VS Code extension uses the same line length as `make format` / CI for every Python file, not just files inside `services/scraper/` and `services/api/`.

## Why
The Ruff extension auto-detects `line-length` from each Python file's nearest `pyproject.toml`. Both service `pyproject.toml`s set `line-length = 120`, but a file opened outside those roots (top-level scripts, ad-hoc files, multi-root opens) silently falls back to Ruff's upstream default of 88 — wrapping differently than CI. Pinning the value at the workspace level removes that drift.

This is a workspace-config-only change; no Python or TS code is touched.

## Test plan
- [ ] Reload the VS Code window and confirm Python files inside `services/api/` and `services/scraper/` still format identically on save.
- [ ] Open a `.py` file outside both service roots, paste a line ~100 chars long, save, confirm Ruff does NOT wrap it (would have wrapped at 88 before this change).
- [ ] `make pre-commit` on a separate branch with Python edits stays green (no behavior change for ruff CLI, which still reads `pyproject.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)