### PR TITLE
refactor(scraper): clean up runner orchestration and DLQ wiring

### DIFF
--- a/services/scraper/src/scraper/client.py
+++ b/services/scraper/src/scraper/client.py
@@ -5,23 +5,6 @@ from loguru import logger
 
 from scraper.models import DeadListing, Listing
 
-# Subset of Listing fields the API's DeadListingIn schema accepts. Excludes
-# enrichment fields (bag_id, property_type, bedrooms, area_sqm) — a dead
-# listing by definition didn't reach BAG enrichment.
-_DEAD_LISTING_FIELDS = {
-    "website",
-    "detail_url",
-    "title",
-    "price",
-    "city",
-    "street",
-    "house_number",
-    "house_letter",
-    "house_number_suffix",
-    "postcode",
-    "image_url",
-}
-
 
 class BackendClient:
     def __init__(self, base_url: str, api_key: str) -> None:
@@ -60,7 +43,7 @@ class BackendClient:
             "finished_at": finished_at.isoformat(),
             "error_message": error_message,
             "listings": [listing.model_dump() for listing in listings],
-            "dead_listings": [_dead_listing_payload(dead) for dead in dead_listings],
+            "dead_listings": [dead.model_dump() for dead in dead_listings],
         }
         response = self.client.post(f"/internal/v1/scrape-runs/{website}/results", json=payload)
         response.raise_for_status()
@@ -70,7 +53,3 @@ class BackendClient:
             f"and {len(dead_listings)} dead for {website}"
         )
         return result
-
-
-def _dead_listing_payload(dead: DeadListing) -> dict:
-    return {**dead.listing.model_dump(include=_DEAD_LISTING_FIELDS), "reason": dead.reason}

--- a/services/scraper/src/scraper/fetch/http.py
+++ b/services/scraper/src/scraper/fetch/http.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import requests
 from loguru import logger
 
@@ -19,6 +21,12 @@ class HttpFetch:
         self.timeout = timeout
         self.session = requests.Session()
         self.session.headers.update(_BROWSER_HEADERS)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
     def fetch(self, url: str) -> str:
         logger.debug(f"HTTP fetch: {url}")

--- a/services/scraper/src/scraper/fetch/playwright.py
+++ b/services/scraper/src/scraper/fetch/playwright.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from loguru import logger
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import sync_playwright
@@ -8,6 +10,12 @@ class PlaywrightFetch:
         self.browser_url = browser_url
         self._pw = None
         self._browser = None
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
     def fetch(self, url: str) -> str:
         logger.debug(f"Playwright fetch: {url}")

--- a/services/scraper/src/scraper/models.py
+++ b/services/scraper/src/scraper/models.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from pydantic import BaseModel
 
 from scraper.enums import Website
@@ -21,10 +23,26 @@ class Listing(BaseModel):
     website: Website
 
 
+# Mirrors the API's DeadListingIn schema 1:1 — pre-enrichment fields
+# (bag_id, property_type, bedrooms, area_sqm don't apply since these
+# listings never reached enrichment).
 class DeadListing(BaseModel):
-    """A listing that failed BAG enrichment terminally — pairs the scraped
-    Listing with the structured reason the runner derived from the matcher's
-    outcome and the listing's own input quality."""
-
-    listing: Listing
+    detail_url: str
+    title: str
+    price: str
+    city: str
+    street: str | None = None
+    house_number: int | None = None
+    house_letter: str | None = None
+    house_number_suffix: str | None = None
+    postcode: str | None = None
+    image_url: str | None = None
+    website: Website
     reason: str
+
+    @classmethod
+    def from_listing(cls, listing: Listing, reason: str) -> Self:
+        return cls(
+            **listing.model_dump(exclude={"bag_id", "property_type", "bedrooms", "area_sqm"}),
+            reason=reason,
+        )

--- a/services/scraper/src/scraper/protocols.py
+++ b/services/scraper/src/scraper/protocols.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, Self
 
 from scraper.enums import Website
 from scraper.models import Listing
@@ -8,6 +8,8 @@ from scraper.models import Listing
 class FetchStrategy(Protocol):
     def fetch(self, url: str) -> str: ...
     def close(self) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, *exc: object) -> None: ...
 
 
 class Scraper(Protocol):

--- a/services/scraper/src/scraper/runner.py
+++ b/services/scraper/src/scraper/runner.py
@@ -72,7 +72,7 @@ def run() -> None:
                         matched_listings.append(listing)
                     else:
                         reason = _classify_dead_reason(listing, result)
-                        dead_listings.append(DeadListing(listing=listing, reason=reason))
+                        dead_listings.append(DeadListing.from_listing(listing, reason))
     except Exception as e:
         error_message = str(e)
         logger.exception(f"Scraping failed for {website}")

--- a/services/scraper/src/scraper/runner.py
+++ b/services/scraper/src/scraper/runner.py
@@ -9,6 +9,7 @@ from scraper.enums import Website
 from scraper.fetch.http import HttpFetch
 from scraper.fetch.playwright import PlaywrightFetch
 from scraper.models import DeadListing, Listing
+from scraper.protocols import FetchStrategy
 from scraper.scrapers.funda import FundaScraper
 from scraper.scrapers.pararius import ParariusScraper
 from scraper.scrapers.vastgoed_nl import VastgoedNLScraper
@@ -23,63 +24,36 @@ SCRAPER_MAP = {
 
 def run() -> None:
     settings = Settings()
-    logger.remove()
-    logger.add(sys.stderr, level=settings.log_level)
+    _configure_logging(settings.log_level)
 
     website = Website(settings.website)
     logger.info(f"Starting scraper for {website}")
 
-    # Initialize backend client
     client = BackendClient(base_url=settings.backend_api_url, api_key=settings.realty_api_key)
     if not client.health_check():
         logger.error("Backend API is unreachable — aborting")
         sys.exit(1)
 
-    # Get last successful run timestamp
     since = client.get_last_successful_run(website)
     logger.info(f"Last successful run: {since or 'never'}")
 
-    # Initialize fetch strategy
-    if website in [Website.FUNDA, Website.PARARIUS]:
-        fetch: HttpFetch | PlaywrightFetch = PlaywrightFetch(browser_url=settings.browser_url)
-    else:
-        fetch = HttpFetch()
-
     started_at = datetime.now(UTC)
-    error_message = None
+    error_message: str | None = None
     matched_listings: list[Listing] = []
     dead_listings: list[DeadListing] = []
 
     try:
-        with fetch:
-            scraper_class = SCRAPER_MAP[website]
-            scraper = scraper_class(fetch=fetch)
+        with _make_fetch(website, settings) as fetch:
+            scraper = SCRAPER_MAP[website](fetch=fetch)
             listings = scraper.scrape(since=since)
             logger.info(f"Scraped {len(listings)} listings from {website}")
-
-            with ParquetBagLookup() as bag:
-                for listing in listings:
-                    result = bag.lookup(
-                        street=listing.street,
-                        house_number=listing.house_number,
-                        house_letter=listing.house_letter,
-                        house_number_suffix=listing.house_number_suffix,
-                        postcode=listing.postcode,
-                        city=listing.city,
-                    )
-                    if isinstance(result, BagMatch):
-                        apply_bag_match(listing, result)
-                        matched_listings.append(listing)
-                    else:
-                        reason = _classify_dead_reason(listing, result)
-                        dead_listings.append(DeadListing.from_listing(listing, reason))
-    except Exception as e:
-        error_message = str(e)
+            matched_listings, dead_listings = _enrich(listings)
+    except Exception as exc:
+        error_message = str(exc)
         logger.exception(f"Scraping failed for {website}")
-    finally:
-        finished_at = datetime.now(UTC)
 
-    # Submit results to backend API
+    finished_at = datetime.now(UTC)
+
     try:
         client.submit_results(
             website=website,
@@ -97,6 +71,41 @@ def run() -> None:
         sys.exit(1)
 
     logger.info(f"Scraper for {website} completed successfully")
+
+
+def _configure_logging(level: str) -> None:
+    logger.remove()
+    logger.add(sys.stderr, level=level)
+
+
+def _make_fetch(website: Website, settings: Settings) -> FetchStrategy:
+    # Funda and Pararius hide listing markup behind client-side rendering,
+    # so they need a real browser. VastgoedNL serves rendered HTML and runs
+    # fine over plain HTTP.
+    if website in {Website.FUNDA, Website.PARARIUS}:
+        return PlaywrightFetch(browser_url=settings.browser_url)
+    return HttpFetch()
+
+
+def _enrich(listings: list[Listing]) -> tuple[list[Listing], list[DeadListing]]:
+    matched: list[Listing] = []
+    dead: list[DeadListing] = []
+    with ParquetBagLookup() as bag:
+        for listing in listings:
+            result = bag.lookup(
+                street=listing.street,
+                house_number=listing.house_number,
+                house_letter=listing.house_letter,
+                house_number_suffix=listing.house_number_suffix,
+                postcode=listing.postcode,
+                city=listing.city,
+            )
+            if isinstance(result, BagMatch):
+                apply_bag_match(listing, result)
+                matched.append(listing)
+            else:
+                dead.append(DeadListing.from_listing(listing, _classify_dead_reason(listing, result)))
+    return matched, dead
 
 
 def _classify_dead_reason(listing: Listing, bag_reason: BagMissReason) -> str:

--- a/services/scraper/src/scraper/runner.py
+++ b/services/scraper/src/scraper/runner.py
@@ -41,13 +41,9 @@ def run() -> None:
 
     # Initialize fetch strategy
     if website in [Website.FUNDA, Website.PARARIUS]:
-        fetch = PlaywrightFetch(browser_url=settings.browser_url)
+        fetch: HttpFetch | PlaywrightFetch = PlaywrightFetch(browser_url=settings.browser_url)
     else:
         fetch = HttpFetch()
-
-    # Create scraper and run
-    scraper_class = SCRAPER_MAP[website]
-    scraper = scraper_class(fetch=fetch)
 
     started_at = datetime.now(UTC)
     error_message = None
@@ -55,30 +51,33 @@ def run() -> None:
     dead_listings: list[DeadListing] = []
 
     try:
-        listings = scraper.scrape(since=since)
-        logger.info(f"Scraped {len(listings)} listings from {website}")
+        with fetch:
+            scraper_class = SCRAPER_MAP[website]
+            scraper = scraper_class(fetch=fetch)
+            listings = scraper.scrape(since=since)
+            logger.info(f"Scraped {len(listings)} listings from {website}")
 
-        with ParquetBagLookup() as bag:
-            for listing in listings:
-                result = bag.lookup(
-                    street=listing.street,
-                    house_number=listing.house_number,
-                    house_letter=listing.house_letter,
-                    house_number_suffix=listing.house_number_suffix,
-                    postcode=listing.postcode,
-                    city=listing.city,
-                )
-                if isinstance(result, BagMatch):
-                    apply_bag_match(listing, result)
-                    matched_listings.append(listing)
-                else:
-                    dead_listings.append(DeadListing(listing=listing, reason=_classify_dead_reason(listing, result)))
+            with ParquetBagLookup() as bag:
+                for listing in listings:
+                    result = bag.lookup(
+                        street=listing.street,
+                        house_number=listing.house_number,
+                        house_letter=listing.house_letter,
+                        house_number_suffix=listing.house_number_suffix,
+                        postcode=listing.postcode,
+                        city=listing.city,
+                    )
+                    if isinstance(result, BagMatch):
+                        apply_bag_match(listing, result)
+                        matched_listings.append(listing)
+                    else:
+                        reason = _classify_dead_reason(listing, result)
+                        dead_listings.append(DeadListing(listing=listing, reason=reason))
     except Exception as e:
         error_message = str(e)
         logger.exception(f"Scraping failed for {website}")
     finally:
         finished_at = datetime.now(UTC)
-        fetch.close()
 
     # Submit results to backend API
     try:

--- a/services/scraper/src/scraper/settings.py
+++ b/services/scraper/src/scraper/settings.py
@@ -7,7 +7,6 @@ class Settings(BaseSettings):
 
     # Job-specific
     website: str = Field(...)
-    scrape_scope: str = "all"
 
     # Infrastructure
     backend_api_url: str = "http://localhost:8000"

--- a/services/scraper/tests/conftest.py
+++ b/services/scraper/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Self
 
 import pytest
 
@@ -31,6 +32,12 @@ class MockFetch:
 
     def close(self) -> None:
         pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
 @pytest.fixture

--- a/services/scraper/tests/scrapers/test_base.py
+++ b/services/scraper/tests/scrapers/test_base.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import pytest
 
 from scraper.scrapers.base import BaseScraper, ScrapingException
@@ -12,6 +14,12 @@ class _StubFetch:
 
     def close(self) -> None:
         pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
 def test_no_markers_never_flags_block():

--- a/services/scraper/tests/scrapers/test_funda.py
+++ b/services/scraper/tests/scrapers/test_funda.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Self
 
 import pytest
 
@@ -30,6 +31,12 @@ def test_get_last_page_parses_query_string(html, expected):
 
         def close(self) -> None:
             pass
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
 
     scraper = FundaScraper(fetch=_Fetch(), base_url="https://www.funda.nl/zoeken/koop")
     assert scraper._get_last_page() == expected

--- a/services/scraper/tests/test_dead_letter_queue.py
+++ b/services/scraper/tests/test_dead_letter_queue.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from scraper.bag import BagMissReason
-from scraper.client import _dead_listing_payload
 from scraper.enums import Website
 from scraper.models import DeadListing, Listing
 from scraper.runner import _classify_dead_reason
@@ -33,26 +32,24 @@ def test_classify_dead_reason_passes_through_bag_ambiguous() -> None:
     assert _classify_dead_reason(listing, BagMissReason.AMBIGUOUS) == "bag_ambiguous"
 
 
-def test_dead_listing_payload_drops_enrichment_fields() -> None:
-    """The API's DeadListingIn schema only accepts pre-enrichment fields plus
-    `reason` — bag_id and the property metadata are populated by the matcher
-    and have no place on a row that didn't match."""
-    dead = DeadListing(
-        listing=_listing(
-            street="Klaterweg",
-            house_number=9,
-            house_letter="R",
-            house_number_suffix="A59",
-            postcode="1271KE",
-            bag_id="0501100000000001",
-            property_type="apartment",
-            bedrooms=2,
-            area_sqm=70.0,
-            image_url="https://example.com/img.jpg",
-        ),
-        reason="bag_no_match",
+def test_from_listing_drops_enrichment_fields() -> None:
+    """DeadListing mirrors the API's DeadListingIn schema 1:1 — bag_id and the
+    property metadata are populated by the matcher and have no place on a row
+    that didn't match."""
+    listing = _listing(
+        street="Klaterweg",
+        house_number=9,
+        house_letter="R",
+        house_number_suffix="A59",
+        postcode="1271KE",
+        bag_id="0501100000000001",
+        property_type="apartment",
+        bedrooms=2,
+        area_sqm=70.0,
+        image_url="https://example.com/img.jpg",
     )
-    payload = _dead_listing_payload(dead)
+    dead = DeadListing.from_listing(listing, reason="bag_no_match")
+    payload = dead.model_dump()
     assert payload["reason"] == "bag_no_match"
     assert payload["street"] == "Klaterweg"
     assert payload["house_letter"] == "R"


### PR DESCRIPTION
## Summary

Holistic follow-up to PR #115 — four behaviour-preserving refactors that came out of a code review of the scraper service. Each is an atomic commit so any one can be reverted independently if needed.

1. **Fetch strategies as context managers.** `HttpFetch` and `PlaywrightFetch` already exposed `close()`; adding `__enter__`/`__exit__` lets the runner manage their lifecycle through `with fetch:` instead of a `try/finally` with manual `fetch.close()`. The scrape body fits naturally inside that block now.
2. **Flatten `DeadListing`.** It now mirrors the API's `DeadListingIn` schema 1:1 instead of wrapping a `Listing` under a `listing` key. Construction goes through `DeadListing.from_listing(listing, reason)`, which uses `model_dump(exclude={\"bag_id\", ...})` to drop enrichment fields. The client's `_dead_listing_payload` helper and parallel field set are gone — `dead.model_dump()` is enough.
3. **Extract `run()` helpers.** Pulls `_configure_logging`, `_make_fetch`, and `_enrich` out so the top-level entry point is just orchestration: settings → client setup → scrape inside fetch's context → enrich → submit. `FetchStrategy` gains `__enter__`/`__exit__` on the protocol so the runner's `with _make_fetch(...) as fetch:` typechecks without a union annotation.
4. **Drop unused `scrape_scope` setting.** Declared with default `\"all\"` but never read anywhere in the scraper.

## Test plan

- [x] `cd services/scraper && uv run pytest tests/ -v` — 84 passed at every commit
- [x] `make pre-commit` — lint, format, types, JS lint all clean
- [ ] Smoke run scraper against staging Postgres and confirm the run still produces matched listings + DLQ rows the same way (no behaviour change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)