### PR TITLE
fix(scraper): postcode-typo fallback to street+number+city in BAG lookup

### DIFF
--- a/services/scraper/src/scraper/bag.py
+++ b/services/scraper/src/scraper/bag.py
@@ -157,17 +157,39 @@ class ParquetBagLookup:
         city: str,
     ) -> pl.DataFrame:
         df = self._df_loaded()
-        if postcode:
-            collected = df.filter(
+        if not postcode:
+            return self._collect_by_street_number_city(df, street, house_number, city)
+        collected = cast(
+            pl.DataFrame,
+            df.filter(
                 (pl.col("postcode") == _normalise_postcode(postcode)) & (pl.col("huisnummer") == house_number)
-            ).collect()
-        else:
-            collected = df.filter(
+            ).collect(),
+        )
+        if collected.height == 0 and street and city:
+            # Source-side postcode typos (one bad character) were dropping otherwise-valid
+            # listings into the DLQ — retry on the same fields the no-postcode branch uses.
+            logger.debug(
+                f"Postcode {postcode} matched no BAG rows; retrying with street+number+city "
+                f"({street} {house_number}, {city})"
+            )
+            return self._collect_by_street_number_city(df, street, house_number, city)
+        return collected
+
+    @staticmethod
+    def _collect_by_street_number_city(
+        df: pl.LazyFrame,
+        street: str | None,
+        house_number: int,
+        city: str,
+    ) -> pl.DataFrame:
+        return cast(
+            pl.DataFrame,
+            df.filter(
                 (pl.col("straatnaam").str.to_lowercase() == (street or "").lower())
                 & (pl.col("huisnummer") == house_number)
                 & (pl.col("woonplaats").str.to_lowercase() == _canonicalise_city(city).lower())
-            ).collect()
-        return cast(pl.DataFrame, collected)
+            ).collect(),
+        )
 
     @staticmethod
     def _filter_exact_pair(

--- a/services/scraper/tests/test_bag.py
+++ b/services/scraper/tests/test_bag.py
@@ -548,6 +548,49 @@ def test_lookup_silent_when_house_number_missing(bag_parquet: Path, loguru_caplo
     assert not any("No BAG match" in record.message for record in loguru_caplog.records)
 
 
+def test_postcode_typo_falls_back_to_street_number_city(bag_parquet: Path) -> None:
+    """A one-character postcode typo on the source ('9901AB' instead of '9901AA')
+    must not dead-letter the listing — fall back to street + number + city."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Snelgersmastraat",
+            house_number=3,
+            house_letter=None,
+            house_number_suffix=None,
+            postcode="9901 AB",
+            city="Appingedam",
+        )
+    assert _bag_id(match) == "0003200000133985"
+
+
+def test_postcode_miss_without_street_returns_no_match(bag_parquet: Path) -> None:
+    """Fallback needs street to fire — without it, postcode miss stays NO_MATCH."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street=None,
+            house_number=3,
+            house_letter=None,
+            house_number_suffix=None,
+            postcode="9901 AB",
+            city="Appingedam",
+        )
+    assert match is BagMissReason.NO_MATCH
+
+
+def test_postcode_miss_without_city_returns_no_match(bag_parquet: Path) -> None:
+    """Fallback needs city to fire — without it, postcode miss stays NO_MATCH."""
+    with ParquetBagLookup(bag_parquet) as bag:
+        match = bag.lookup(
+            street="Snelgersmastraat",
+            house_number=3,
+            house_letter=None,
+            house_number_suffix=None,
+            postcode="9901 AB",
+            city="",
+        )
+    assert match is BagMissReason.NO_MATCH
+
+
 def test_den_haag_alias_resolves_via_no_postcode_fallback(bag_parquet: Path) -> None:
     """A VastgoedNL-style listing without a postcode lookups by street + city;
     "Den Haag" must alias to BAG's canonical "'s-Gravenhage" or the row is missed."""


### PR DESCRIPTION
## Summary

- Smoke testing #116 surfaced source listings with a one-character postcode typo (e.g. `Sytsingawiersterleane 33`, `Boslaan 131` in Den Haag) being dropped into `dead_listings` even though the row exists in BAG under the correct postcode.
- The no-postcode branch of `_find_candidates` already searches by `straatnaam + huisnummer + woonplaats`. This PR extends the postcode branch to retry on the same shape when the postcode-keyed filter returns zero candidates, gated on `street and city` being non-empty.
- Refactors the no-postcode filter into a shared `_collect_by_street_number_city` helper so both call sites use the same predicates (city alias map, woonplaats lowercase compare).
- Logs the retry at `debug` so the fast path stays quiet but the fallback is visible when investigating.

## Test plan

- [x] 3 new bag tests — typo postcode resolves, postcode-miss without street stays `NO_MATCH`, postcode-miss without city stays `NO_MATCH`
- [x] Existing 31 bag tests still pass (no regression on disambiguation cascade)
- [x] Full scraper suite green (87 tests)
- [x] `make pre-commit` clean for Python (ruff lint/format + ty typecheck)
- [ ] Smoke test on staging — `Sytsingawiersterleane 33` and `Boslaan 131` listings now land in `listings` with `bag_id` set instead of `dead_listings (bag_no_match)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)