### PR TITLE
refactor(repo): rename ListingUrl to Listing

### DIFF
--- a/apps/mobile/src/types/index.ts
+++ b/apps/mobile/src/types/index.ts
@@ -62,7 +62,7 @@ export interface ScrapeRun {
   status: "running" | "success" | "failed";
   listings_found: number;
   new_residences_count: number;
-  new_listing_urls_count: number;
+  new_listings_count: number;
   error_message: string | null;
   duration_seconds: number | null;
 }

--- a/services/api/scraping/admin.py
+++ b/services/api/scraping/admin.py
@@ -2,12 +2,12 @@ from django.contrib import admin, messages
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 
-from scraping.models import DeadResidence, ListingUrl, Residence, ScrapeRun
+from scraping.models import DeadResidence, Listing, Residence, ScrapeRun
 from scraping.services import DeadResidencePromotionError, promote_dead_residence
 
 
-class ListingUrlInline(admin.TabularInline):
-    model = ListingUrl
+class ListingInline(admin.TabularInline):
+    model = Listing
     extra = 0
     readonly_fields = ("url", "website", "first_seen_at")
     can_delete = False
@@ -33,12 +33,12 @@ class ResidenceAdmin(admin.ModelAdmin):
     search_fields = ("title", "street", "postcode", "bag_id")
     ordering = ("-scraped_at",)
     readonly_fields = ("created_at", "updated_at")
-    inlines = (ListingUrlInline,)
+    inlines = (ListingInline,)
 
 
-@admin.register(ListingUrl)
-class ListingUrlAdmin(admin.ModelAdmin):
-    list_display = ("id", "url", "website", "listing", "first_seen_at")
+@admin.register(Listing)
+class ListingAdmin(admin.ModelAdmin):
+    list_display = ("id", "url", "website", "residence", "first_seen_at")
     list_filter = ("website",)
     search_fields = ("url",)
     ordering = ("-first_seen_at",)
@@ -126,7 +126,7 @@ class ScrapeRunAdmin(admin.ModelAdmin):
         "finished_at",
         "listings_found",
         "new_residences_count",
-        "new_listing_urls_count",
+        "new_listings_count",
         "duration_seconds",
     )
     list_filter = ("website", "status")

--- a/services/api/scraping/api.py
+++ b/services/api/scraping/api.py
@@ -9,7 +9,7 @@ from ninja import NinjaAPI, Router, Schema
 from ninja.responses import Status
 from ninja.security import APIKeyHeader
 
-from scraping.models import DeadResidence, ListingUrl, Residence, ScrapeRun, ScrapeRunStatus, Website
+from scraping.models import DeadResidence, Listing, Residence, ScrapeRun, ScrapeRunStatus, Website
 from scraping.schemas import DeadResidenceIn, ResidenceIn, ScrapeResultsIn, ScrapeRunOut
 
 # Fields to fill on existing residences only when the stored value is NULL.
@@ -84,7 +84,7 @@ def submit_scrape_results(request, website: Website, payload: ScrapeResultsIn):
     run_status = ScrapeRunStatus.FAILED if payload.error_message else ScrapeRunStatus.SUCCESS
 
     with transaction.atomic():
-        new_residences_count, new_listing_urls_count = _ingest_residences(deduped, scraped_at=now)
+        new_residences_count, new_listings_count = _ingest_residences(deduped, scraped_at=now)
         _upsert_dead_residences(payload.dead_listings, scraped_at=now)
 
         scrape_run = ScrapeRun.objects.create(
@@ -94,14 +94,14 @@ def submit_scrape_results(request, website: Website, payload: ScrapeResultsIn):
             status=run_status,
             listings_found=len(payload.listings),
             new_residences_count=new_residences_count,
-            new_listing_urls_count=new_listing_urls_count,
+            new_listings_count=new_listings_count,
             error_message=payload.error_message,
             duration_seconds=duration,
         )
 
     logger.info(
         f"Scrape run for {website}: {new_residences_count} new residences / "
-        f"{new_listing_urls_count} new urls / {len(payload.listings)} found, "
+        f"{new_listings_count} new listings / {len(payload.listings)} found, "
         f"{len(payload.dead_listings)} dead in {duration:.1f}s"
     )
     return scrape_run
@@ -119,7 +119,7 @@ def _dedup_by_bag_id(items: list[ResidenceIn]) -> list[ResidenceIn]:
 
 
 def _ingest_residences(items: list[ResidenceIn], *, scraped_at: datetime) -> tuple[int, int]:
-    """Upsert residences, returning (new_residences_count, new_listing_urls_count).
+    """Upsert residences, returning (new_residences_count, new_listings_count).
 
     The "existing" snapshot is taken before any writes so newly-created rows
     aren't counted as pre-existing.
@@ -127,7 +127,7 @@ def _ingest_residences(items: list[ResidenceIn], *, scraped_at: datetime) -> tup
     payload_bag_ids = {item.bag_id for item in items}
     payload_urls = {item.detail_url for item in items}
     existing_bag_ids = set(Residence.objects.filter(bag_id__in=payload_bag_ids).values_list("bag_id", flat=True))
-    existing_urls = set(ListingUrl.objects.filter(url__in=payload_urls).values_list("url", flat=True))
+    existing_urls = set(Listing.objects.filter(url__in=payload_urls).values_list("url", flat=True))
 
     for item in items:
         _upsert_residence(item, scraped_at=scraped_at)
@@ -145,11 +145,11 @@ def _upsert_residence(item: ResidenceIn, *, scraped_at: datetime) -> Residence:
 
     # If the URL is already attached to a different Residence (e.g. a parser
     # fix changed the BAG match across runs), keep the existing FK. Re-wiring
-    # URLs between residences is intentionally a manual /admin operation, not
-    # the auto-ingest path.
-    ListingUrl.objects.get_or_create(
+    # listings between residences is intentionally a manual /admin operation,
+    # not the auto-ingest path.
+    Listing.objects.get_or_create(
         url=item.detail_url,
-        defaults={"listing": residence, "website": item.website},
+        defaults={"residence": residence, "website": item.website},
     )
     return residence
 
@@ -205,7 +205,7 @@ def _upsert_dead_residences(dead: list[DeadResidenceIn], *, scraped_at: datetime
         return
 
     urls = [item.detail_url for item in dead]
-    promoted_urls = set(ListingUrl.objects.filter(url__in=urls).values_list("url", flat=True))
+    promoted_urls = set(Listing.objects.filter(url__in=urls).values_list("url", flat=True))
 
     for item in dead:
         if item.detail_url in promoted_urls:

--- a/services/api/scraping/migrations/0006_rename_listingurl_to_listing.py
+++ b/services/api/scraping/migrations/0006_rename_listingurl_to_listing.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("scraping", "0005_rename_listing_to_residence"),
+    ]
+
+    # `migrations.RenameIndex` is a Django >= 4.1 op; ty / django-types stubs
+    # don't list it yet, so each call carries `# ty: ignore[unresolved-attribute]`.
+    operations = [
+        migrations.RenameModel(
+            old_name="ListingUrl",
+            new_name="Listing",
+        ),
+        migrations.RenameField(
+            model_name="listing",
+            old_name="listing",
+            new_name="residence",
+        ),
+        migrations.RenameField(
+            model_name="scraperun",
+            old_name="new_listing_urls_count",
+            new_name="new_listings_count",
+        ),
+        migrations.RenameIndex(  # ty: ignore[unresolved-attribute]
+            model_name="listing",
+            new_name="idx_listings_website",
+            old_name="idx_listing_urls_website",
+        ),
+        migrations.AlterModelTable(
+            name="listing",
+            table="listings",
+        ),
+    ]

--- a/services/api/scraping/models.py
+++ b/services/api/scraping/models.py
@@ -27,10 +27,11 @@ class DeadResidenceReason(models.TextChoices):
 
 
 class Residence(models.Model):
-    """One row per physical property, keyed on its BAG ID. Per-portal URLs live
-    in `ListingUrl` so the same property listed on Funda + Pararius collapses
-    to a single row. Status mirrors the portal's own badge (`Nieuw` /
-    `Verkocht onder voorbehoud` / `Verkocht`) and updates on every scrape."""
+    """One row per physical property, keyed on its BAG ID. Per-portal listings
+    live in `Listing` so the same property advertised on Funda + Pararius
+    collapses to a single residence row. Status mirrors the portal's own badge
+    (`Nieuw` / `Verkocht onder voorbehoud` / `Verkocht`) and updates on every
+    scrape."""
 
     bag_id = models.CharField(max_length=16, unique=True)
     title = models.CharField(max_length=500)
@@ -62,16 +63,19 @@ class Residence(models.Model):
         return f"{self.title} ({self.city})"
 
 
-class ListingUrl(models.Model):
-    listing = models.ForeignKey(Residence, related_name="listing_urls", on_delete=models.CASCADE)
+class Listing(models.Model):
+    """One row per portal advertisement. Multiple `Listing`s may point at the
+    same `Residence` when the property is advertised across portals."""
+
+    residence = models.ForeignKey(Residence, related_name="listings", on_delete=models.CASCADE)
     website = models.CharField(max_length=20, choices=Website.choices)
     url = models.URLField(max_length=500, unique=True)
     first_seen_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        db_table = "listing_urls"
+        db_table = "listings"
         indexes = [
-            models.Index(fields=["website", "first_seen_at"], name="idx_listing_urls_website"),
+            models.Index(fields=["website", "first_seen_at"], name="idx_listings_website"),
         ]
 
     def __str__(self) -> str:
@@ -136,7 +140,7 @@ class ScrapeRun(models.Model):
     status = models.CharField(max_length=10, choices=ScrapeRunStatus.choices)
     listings_found = models.PositiveIntegerField(default=0)
     new_residences_count = models.PositiveIntegerField(default=0)
-    new_listing_urls_count = models.PositiveIntegerField(default=0)
+    new_listings_count = models.PositiveIntegerField(default=0)
     error_message = models.TextField(null=True, blank=True)
     duration_seconds = models.FloatField(null=True, blank=True)
 

--- a/services/api/scraping/schemas.py
+++ b/services/api/scraping/schemas.py
@@ -37,7 +37,7 @@ class ResidenceIn(Schema):
     status: ListingStatus = ListingStatus.NEW
 
 
-class ListingUrlOut(Schema):
+class ListingOut(Schema):
     url: str
     website: Website
     first_seen_at: datetime
@@ -62,7 +62,7 @@ class ResidenceOut(Schema):
     status: ListingStatus
     scraped_at: datetime
     created_at: datetime
-    listing_urls: list[ListingUrlOut]
+    listings: list[ListingOut]
 
 
 class ScrapeRunOut(Schema):
@@ -73,7 +73,7 @@ class ScrapeRunOut(Schema):
     status: ScrapeRunStatus
     listings_found: int
     new_residences_count: int
-    new_listing_urls_count: int
+    new_listings_count: int
     error_message: str | None
     duration_seconds: float | None
 

--- a/services/api/scraping/services.py
+++ b/services/api/scraping/services.py
@@ -1,7 +1,7 @@
 from django.db import transaction
 
 from scraping.api import _parse_price_eur
-from scraping.models import DeadResidence, ListingUrl, Residence
+from scraping.models import DeadResidence, Listing, Residence
 
 # Subset of api._COMPLEMENT_FIELDS — DeadResidence carries a strict subset of
 # the Residence schema (no property_type / bedrooms / area_sqm).
@@ -32,7 +32,7 @@ def promote_dead_residence(dead: DeadResidence) -> Residence:
         missing = ", ".join(dead.missing_promotion_fields)
         raise DeadResidencePromotionError(f"Not ready for promotion. Missing: {missing}")
 
-    has_conflict = ListingUrl.objects.filter(url=dead.detail_url).exclude(listing__bag_id=dead.bag_id).exists()
+    has_conflict = Listing.objects.filter(url=dead.detail_url).exclude(residence__bag_id=dead.bag_id).exists()
     if has_conflict:
         raise DeadResidencePromotionError(f"URL {dead.detail_url} is already attached to a different residence")
 
@@ -44,9 +44,9 @@ def promote_dead_residence(dead: DeadResidence) -> Residence:
         if not created:
             _complement_residence_from_dead(residence, dead)
 
-        ListingUrl.objects.get_or_create(
+        Listing.objects.get_or_create(
             url=dead.detail_url,
-            defaults={"listing": residence, "website": dead.website},
+            defaults={"residence": residence, "website": dead.website},
         )
         dead.delete()
 

--- a/services/api/tests/factories.py
+++ b/services/api/tests/factories.py
@@ -6,8 +6,8 @@ from factory.django import DjangoModelFactory
 from scraping.models import (
     DeadResidence,
     DeadResidenceReason,
+    Listing,
     ListingStatus,
-    ListingUrl,
     Residence,
     ScrapeRun,
     ScrapeRunStatus,
@@ -33,11 +33,11 @@ class ResidenceFactory(DjangoModelFactory):
     scraped_at = factory.LazyFunction(lambda: datetime.now(UTC))
 
 
-class ListingUrlFactory(DjangoModelFactory):
+class ListingFactory(DjangoModelFactory):
     class Meta:
-        model = ListingUrl
+        model = Listing
 
-    listing = factory.SubFactory(ResidenceFactory)
+    residence = factory.SubFactory(ResidenceFactory)
     website = Website.FUNDA
     url = factory.Sequence(lambda n: f"https://example.com/listing/{n}")
 
@@ -65,5 +65,5 @@ class ScrapeRunFactory(DjangoModelFactory):
     status = ScrapeRunStatus.SUCCESS
     listings_found = 0
     new_residences_count = 0
-    new_listing_urls_count = 0
+    new_listings_count = 0
     duration_seconds = 300.0

--- a/services/api/tests/test_dead_residence_promotion.py
+++ b/services/api/tests/test_dead_residence_promotion.py
@@ -2,10 +2,10 @@ from datetime import UTC, datetime, timedelta
 from typing import cast
 
 import pytest
-from scraping.models import DeadResidence, DeadResidenceReason, ListingUrl, Residence, Website
+from scraping.models import DeadResidence, DeadResidenceReason, Listing, Residence, Website
 from scraping.services import DeadResidencePromotionError, promote_dead_residence
 
-from tests.factories import DeadResidenceFactory, ListingUrlFactory, ResidenceFactory
+from tests.factories import DeadResidenceFactory, ListingFactory, ResidenceFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -59,7 +59,7 @@ def test_promote_creates_listing_url_and_deletes_dead():
     assert residence.city == "Amsterdam"
     assert residence.street == "Damrak"
     assert residence.postcode == "1012JS"
-    assert ListingUrl.objects.filter(url="https://example.com/dead/promote-1", listing=residence).exists()
+    assert Listing.objects.filter(url="https://example.com/dead/promote-1", residence=residence).exists()
     assert not DeadResidence.objects.filter(pk=dead.pk).exists()
 
 
@@ -76,7 +76,7 @@ def test_promote_reuses_existing_residence_when_bag_id_matches():
             scraped_at=datetime.now(UTC),
         ),
     )
-    ListingUrlFactory(listing=existing, website=Website.FUNDA, url="https://funda.example/orig")
+    ListingFactory(residence=existing, website=Website.FUNDA, url="https://funda.example/orig")
 
     dead = cast(
         DeadResidence,
@@ -105,7 +105,7 @@ def test_promote_reuses_existing_residence_when_bag_id_matches():
     # Complement-only: NULL fields are filled from dead row.
     assert residence.postcode == "1011AB"
     # Both URLs are now linked to the same residence.
-    urls = set(ListingUrl.objects.filter(listing=residence).values_list("url", flat=True))
+    urls = set(Listing.objects.filter(residence=residence).values_list("url", flat=True))
     assert urls == {"https://funda.example/orig", "https://pararius.example/dead"}
     assert not DeadResidence.objects.filter(pk=dead.pk).exists()
 
@@ -150,7 +150,7 @@ def test_promote_raises_when_not_ready():
 
 def test_promote_raises_when_url_attached_to_different_residence():
     other = cast(Residence, ResidenceFactory(bag_id="0003200000000004"))
-    ListingUrlFactory(listing=other, url="https://example.com/dead/conflict")
+    ListingFactory(residence=other, url="https://example.com/dead/conflict")
     dead = cast(
         DeadResidence,
         DeadResidenceFactory(
@@ -167,9 +167,9 @@ def test_promote_raises_when_url_attached_to_different_residence():
 
 
 def test_promote_idempotent_when_url_already_attached_to_same_residence():
-    """Re-promoting (or promoting after a manual ListingUrl insert) shouldn't error."""
+    """Re-promoting (or promoting after a manual Listing insert) shouldn't error."""
     existing = cast(Residence, ResidenceFactory(bag_id="0003200000000006"))
-    ListingUrlFactory(listing=existing, url="https://example.com/dead/already")
+    ListingFactory(residence=existing, url="https://example.com/dead/already")
     dead = cast(
         DeadResidence,
         DeadResidenceFactory(
@@ -181,7 +181,7 @@ def test_promote_idempotent_when_url_already_attached_to_same_residence():
     residence = promote_dead_residence(dead)
 
     assert residence.pk == existing.pk
-    assert ListingUrl.objects.filter(url="https://example.com/dead/already").count() == 1
+    assert Listing.objects.filter(url="https://example.com/dead/already").count() == 1
     assert not DeadResidence.objects.filter(pk=dead.pk).exists()
 
 
@@ -190,7 +190,7 @@ def test_upsert_dead_residences_skips_url_already_a_listing_url(
 ):
     """After a promotion, the next scrape run mustn't bounce the URL back into the DLQ."""
     residence = cast(Residence, ResidenceFactory(bag_id="0003200000000007"))
-    ListingUrlFactory(listing=residence, url="https://example.com/dead/already-promoted")
+    ListingFactory(residence=residence, url="https://example.com/dead/already-promoted")
 
     payload = scrape_payload(
         dead_listings=[
@@ -265,7 +265,7 @@ def test_promote_action_promotes_ready_skips_not_ready(admin_client):
 def test_promote_action_continues_after_per_row_error(admin_client):
     """A URL conflict on one row must not block promotion of the others."""
     occupied = cast(Residence, ResidenceFactory(bag_id="0003200000000020"))
-    ListingUrlFactory(listing=occupied, url="https://example.com/dead/conflicting-url")
+    ListingFactory(residence=occupied, url="https://example.com/dead/conflicting-url")
 
     conflicting = cast(
         DeadResidence,

--- a/services/api/tests/test_internal.py
+++ b/services/api/tests/test_internal.py
@@ -5,15 +5,15 @@ import pytest
 from scraping.models import (
     DeadResidence,
     DeadResidenceReason,
+    Listing,
     ListingStatus,
-    ListingUrl,
     Residence,
     ScrapeRun,
     ScrapeRunStatus,
     Website,
 )
 
-from tests.factories import ListingUrlFactory, ResidenceFactory, ScrapeRunFactory
+from tests.factories import ListingFactory, ResidenceFactory, ScrapeRunFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -71,16 +71,16 @@ def test_submit_results_creates_run_and_residences(client, api_key_headers, scra
     assert body["website"] == website.value
     assert body["listings_found"] == 2
     assert body["new_residences_count"] == 2
-    assert body["new_listing_urls_count"] == 2
+    assert body["new_listings_count"] == 2
     assert body["status"] == ScrapeRunStatus.SUCCESS.value
     assert ScrapeRun.objects.count() == 1
     assert Residence.objects.count() == 2
-    assert ListingUrl.objects.count() == 2
+    assert Listing.objects.count() == 2
 
 
 def test_submit_results_dedups_existing_residences(client, api_key_headers, scrape_payload, residence_payload):
     existing = ResidenceFactory(bag_id="0003200000000001")
-    ListingUrlFactory(listing=existing, url="https://example.com/listing/existing", website=Website.FUNDA)
+    ListingFactory(residence=existing, url="https://example.com/listing/existing", website=Website.FUNDA)
 
     payload = scrape_payload(
         listings=[
@@ -97,9 +97,9 @@ def test_submit_results_dedups_existing_residences(client, api_key_headers, scra
     body = response.json()
     assert body["listings_found"] == 2
     assert body["new_residences_count"] == 1
-    assert body["new_listing_urls_count"] == 1
+    assert body["new_listings_count"] == 1
     assert Residence.objects.count() == 2
-    assert ListingUrl.objects.count() == 2
+    assert Listing.objects.count() == 2
 
 
 def test_submit_results_dedups_within_payload_by_bag_id(client, api_key_headers, scrape_payload, residence_payload):
@@ -152,10 +152,10 @@ def test_submit_results_merges_cross_portal_residence(client, api_key_headers, s
     assert response.status_code == 200
     body = response.json()
     assert body["new_residences_count"] == 0
-    assert body["new_listing_urls_count"] == 1
+    assert body["new_listings_count"] == 1
     assert Residence.objects.count() == 1
     residence = Residence.objects.get()
-    urls = list(residence.listing_urls.values_list("website", "url").order_by("website"))
+    urls = list(residence.listings.values_list("website", "url").order_by("website"))
     assert urls == [
         (Website.FUNDA.value, "https://funda.nl/listing/abc"),
         (Website.PARARIUS.value, "https://pararius.nl/listing/xyz"),

--- a/services/scraper/src/scraper/client.py
+++ b/services/scraper/src/scraper/client.py
@@ -50,7 +50,7 @@ class BackendClient:
         result = response.json()
         logger.info(
             f"Submitted {result['listings_found']} listings "
-            f"({result['new_properties_count']} new properties, "
+            f"({result['new_residences_count']} new residences, "
             f"{result['new_listing_urls_count']} new urls) "
             f"and {len(dead_listings)} dead for {website}"
         )

--- a/services/scraper/src/scraper/client.py
+++ b/services/scraper/src/scraper/client.py
@@ -51,7 +51,7 @@ class BackendClient:
         logger.info(
             f"Submitted {result['listings_found']} listings "
             f"({result['new_residences_count']} new residences, "
-            f"{result['new_listing_urls_count']} new urls) "
+            f"{result['new_listings_count']} new listings) "
             f"and {len(dead_listings)} dead for {website}"
         )
         return result


### PR DESCRIPTION
## Summary

Follow-up to #125. Reclaims the word "listing" for its real-estate-vocabulary meaning — the per-portal advertisement (Funda URL, Pararius URL) — by renaming `ListingUrl` → `Listing`. The deduplicated property entity that it points at is now `Residence` (from #125).

After both PRs the API model layer reads cleanly:

```
Residence (one row per physical property, BAG-keyed)
   └─ Residence.listings → list[Listing]   # per-portal ads
        ├─ Listing.residence    (FK)
        ├─ Listing.website
        └─ Listing.url
```

## Renames

**Model + DB:**
- `ListingUrl` → `Listing`
- Table `listing_urls` → `listings` (free now that the old `Listing` model became `Residence`)
- Index `idx_listing_urls_website` → `idx_listings_website`
- FK `ListingUrl.listing` → `Listing.residence` (it was always pointing at a `Residence`; the field name now matches)
- Reverse relation `Residence.listing_urls` → `Residence.listings`

**Schemas / API:**
- `ListingUrlOut` → `ListingOut`
- `ResidenceOut.listing_urls` field → `ResidenceOut.listings`
- `ScrapeRun.new_listing_urls_count` → `new_listings_count` (model + `ScrapeRunOut` schema + admin)

**Admin:**
- `ListingUrlAdmin` → `ListingAdmin`, `ListingUrlInline` → `ListingInline`

**Tests:**
- `ListingUrlFactory` → `ListingFactory`
- All `ListingUrlFactory(listing=…)` → `ListingFactory(residence=…)`
- All `Listing.objects.filter(listing=…)` → `Listing.objects.filter(residence=…)`
- `residence.listing_urls` → `residence.listings`

**Wire format (coordinated across services):**
- API ScrapeRunOut field `new_listing_urls_count` → `new_listings_count`
- Mobile `ScrapeRun.new_listing_urls_count` → `new_listings_count`
- Scraper `client.py` log line key updated

## Commits

1. `fix(scraper): use new_residences_count from API response` — fixes a stale `result['new_properties_count']` read that's been broken since #125 merged (the scraper was kept out of scope last time and this slipped through). Surfaced while doing the wire-field rename below.
2. `refactor(repo): rename ListingUrl model to Listing` — the actual rename.

## Migration

`0006_rename_listingurl_to_listing.py` uses `RenameModel` + `RenameField` (FK) + `RenameField` (ScrapeRun count) + `RenameIndex` + `AlterModelTable`. Non-destructive, no data movement, runs in a single transaction.

## Out of scope

- Scraper service's own `Listing` Pydantic model and `ListingStatus` enum — already aligned with the new meaning of `Listing` (per-portal scrape result).
- Wire field `ScrapeResultsIn.listings: list[ResidenceIn]` — kept; the scraper sends per-portal scrape results which the API splits into `Residence` + `Listing` rows.

## Deploy notes

Same shape as #125: `RenameModel` + `AlterModelTable` rewrites the table in one shot. At `replicas: 1` and with the api-worker running the migration before the api pod becomes ready, the window is sub-second. Blast radius is the same as #125 (scraper retries on transient HTTP errors, TCP-socket probes don't 500). The structural mitigation (`strategy: Recreate` or `PreSync` migration Job) is still tracked for `realty-ai-platform`.

## Test plan

- [x] API tests: `cd services/api && uv run pytest tests/ -q` — 72 passed
- [x] Scraper tests: 102 passed
- [x] Mobile tests: 18 passed
- [x] Web tests: 7 passed
- [x] `make pre-commit` — all green (lint + format + typecheck + TS lint)
- [x] Migration applied cleanly on a fresh dev DB; `\dt` shows `residences`, `listings`, `dead_residences`, `scrape_runs`; FK on `listings.residence_id` preserved