### PR TITLE
ci(repo): bump ruff-pre-commit from v0.12.9 to v0.15.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.9
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         name: Lint python (scraper)


### PR DESCRIPTION
## Summary

Bumps the ruff hook in `.pre-commit-config.yaml` from `v0.12.9` to `v0.15.12` so local pre-commit catches the same formatting/lint issues CI does.

The hook was three minor releases behind `services/api`'s `ruff>=0.15` constraint, so the older hook silently passed code that CI's `uv run ruff format --check` (running ruff 0.15.9 from the locked venv) flagged. Two recent PRs hit this:

- #128 commit `8f42141 style(api): wrap migration 0008 choice lists over multiple lines`
- #129 commit `3933405 style(api): reformat migration 0009 to match project ruff version`

Both were fallout from the same skew. Bumping to `v0.15.12` (slightly ahead of the venv-locked `0.15.9`) gives a small forward buffer against future `uv sync` patch bumps so the gap doesn't reopen.

## Test plan

- [x] `pre-commit run --all-files` — all Python hooks (ruff-check + ruff-format scraper/api) pass with the bumped rev. (TS hooks fail locally only because node_modules aren't installed in a fresh worktree; CI installs them.)
- [ ] Watch CI on this PR — `lint` and `test` should pass.