### PR TITLE
feat(api): API-side BAG resolution as a Celery task (PR 3/5)

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_realty_alerts
           REALTY_API_KEY: test-key
+          BAG_API_KEY: test-bag-key
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 
   build:

--- a/services/api/realty_api/env.py
+++ b/services/api/realty_api/env.py
@@ -6,6 +6,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     realty_api_key: str = Field(...)
+    bag_api_key: str = Field(...)
     django_secret_key: str | None = None
     allowed_hosts: str = ""
     csrf_trusted_origins: str = ""

--- a/services/api/realty_api/settings/base.py
+++ b/services/api/realty_api/settings/base.py
@@ -16,6 +16,7 @@ BASE_DIR = Path(__file__).resolve().parents[2]
 ALLOWED_HOSTS: list[str] = []
 
 REALTY_API_KEY = SETTINGS.realty_api_key
+BAG_API_KEY = SETTINGS.bag_api_key
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/services/api/realty_api/settings/local.py
+++ b/services/api/realty_api/settings/local.py
@@ -3,6 +3,7 @@ from typing import cast
 
 # Sensible defaults for local dev / test runs. Production must set these explicitly via prod.py.
 os.environ.setdefault("REALTY_API_KEY", "dev-realty-api-key")
+os.environ.setdefault("BAG_API_KEY", "dev-bag-api-key")
 
 from secret_key_generator import secret_key_generator  # noqa: E402
 

--- a/services/api/scraping/api.py
+++ b/services/api/scraping/api.py
@@ -12,6 +12,7 @@ from ninja.security import APIKeyHeader
 from scraping.models import BagStatus, DeadResidence, Listing, Residence, ScrapeRun, ScrapeRunStatus, Website
 from scraping.reconciliation import reconcile_residence
 from scraping.schemas import DeadResidenceIn, ResidenceIn, ScrapeResultsIn, ScrapeRunOut
+from scraping.tasks import resolve_bag
 
 # Fields to fill on existing residences only when the stored value is NULL.
 # We treat 0 / "" as real values, not blanks — bedrooms=0 (studio) and
@@ -78,16 +79,19 @@ def get_active_runs(request):
 
 @internal_router.post("/scrape-runs/{website}/results", response=ScrapeRunOut)
 def submit_scrape_results(request, website: Website, payload: ScrapeResultsIn):
-    deduped = _dedup_by_bag_id(payload.listings)
+    legacy_items, pending_items = _split_by_bag_id(payload.listings)
+    deduped_legacy = _dedup_by_bag_id(legacy_items)
 
     now = datetime.now(UTC)
     duration = (payload.finished_at - payload.started_at).total_seconds()
     run_status = ScrapeRunStatus.FAILED if payload.error_message else ScrapeRunStatus.SUCCESS
 
     with transaction.atomic():
-        new_residences_count, new_listings_count = _ingest_residences(deduped, scraped_at=now)
+        new_residences_count, legacy_new_count = _ingest_residences(deduped_legacy, scraped_at=now)
+        pending_new_count = _ingest_pending_listings(pending_items, scraped_at=now)
         _upsert_dead_residences(payload.dead_listings, scraped_at=now)
 
+        new_listings_count = legacy_new_count + pending_new_count
         scrape_run = ScrapeRun.objects.create(
             website=website,
             started_at=payload.started_at,
@@ -108,6 +112,17 @@ def submit_scrape_results(request, website: Website, payload: ScrapeResultsIn):
     return scrape_run
 
 
+def _split_by_bag_id(items: list[ResidenceIn]) -> tuple[list[ResidenceIn], list[ResidenceIn]]:
+    """Route items by whether the scraper supplied a `bag_id`. Legacy scrapers
+    do; the post-PR-4 scraper won't, and those go through API-side BAG
+    resolution. Empty-string `bag_id` is treated as absent."""
+    legacy: list[ResidenceIn] = []
+    pending: list[ResidenceIn] = []
+    for item in items:
+        (legacy if item.bag_id else pending).append(item)
+    return legacy, pending
+
+
 def _dedup_by_bag_id(items: list[ResidenceIn]) -> list[ResidenceIn]:
     """Keep the first occurrence of each bag_id within a single payload.
     A single scrape can surface the same property twice (duplicate cards on a
@@ -115,7 +130,8 @@ def _dedup_by_bag_id(items: list[ResidenceIn]) -> list[ResidenceIn]:
     """
     seen: dict[str, ResidenceIn] = {}
     for item in items:
-        seen.setdefault(item.bag_id, item)
+        if item.bag_id:
+            seen.setdefault(item.bag_id, item)
     return list(seen.values())
 
 
@@ -125,7 +141,7 @@ def _ingest_residences(items: list[ResidenceIn], *, scraped_at: datetime) -> tup
     The "existing" snapshot is taken before any writes so newly-created rows
     aren't counted as pre-existing.
     """
-    payload_bag_ids = {item.bag_id for item in items}
+    payload_bag_ids = {item.bag_id for item in items if item.bag_id}
     payload_urls = {item.detail_url for item in items}
     existing_bag_ids = set(Residence.objects.filter(bag_id__in=payload_bag_ids).values_list("bag_id", flat=True))
     existing_urls = set(Listing.objects.filter(url__in=payload_urls).values_list("url", flat=True))
@@ -134,6 +150,61 @@ def _ingest_residences(items: list[ResidenceIn], *, scraped_at: datetime) -> tup
         _upsert_residence(item, scraped_at=scraped_at)
 
     return len(payload_bag_ids - existing_bag_ids), len(payload_urls - existing_urls)
+
+
+def _ingest_pending_listings(items: list[ResidenceIn], *, scraped_at: datetime) -> int:
+    """Upsert listings without bag_id, marking them PENDING and queuing
+    `scraping.resolve_bag` for each. Returns count of newly-created listings.
+    Tasks are dispatched on transaction commit so a rollback doesn't leave
+    orphan jobs running against rows that no longer exist."""
+    if not items:
+        return 0
+
+    payload_urls = {item.detail_url for item in items}
+    existing_urls = set(Listing.objects.filter(url__in=payload_urls).values_list("url", flat=True))
+
+    for item in items:
+        listing = _upsert_pending_listing(item, scraped_at=scraped_at)
+        if listing.bag_status == BagStatus.PENDING:
+            transaction.on_commit(lambda pk=listing.pk: resolve_bag.delay(pk))
+
+    return len(payload_urls - existing_urls)
+
+
+def _upsert_pending_listing(item: ResidenceIn, *, scraped_at: datetime) -> Listing:
+    defaults = _listing_defaults_pending(item, scraped_at=scraped_at)
+    listing, created = Listing.objects.get_or_create(url=item.detail_url, defaults=defaults)
+    if not created:
+        # Refresh per-portal scraped fields but don't touch FK / BAG state —
+        # a previously-resolved listing must keep its residence link, and a
+        # listing that already failed terminally shouldn't bounce back to PENDING.
+        for field, value in defaults.items():
+            if field in {"residence", "bag_status", "bag_resolved_at", "bag_failure_reason"}:
+                continue
+            setattr(listing, field, value)
+        listing.save()
+    return listing
+
+
+def _listing_defaults_pending(item: ResidenceIn, *, scraped_at: datetime) -> dict:
+    return {
+        "residence": None,
+        "website": item.website,
+        "title": item.title,
+        "price": item.price,
+        "price_eur": _parse_price_eur(item.price),
+        "image_url": item.image_url,
+        "status": item.status,
+        "scraped_at": scraped_at,
+        "last_seen_at": scraped_at,
+        "street": item.street,
+        "house_number": item.house_number,
+        "house_letter": item.house_letter,
+        "house_number_suffix": item.house_number_suffix,
+        "postcode": item.postcode,
+        "city": item.city,
+        "bag_status": BagStatus.PENDING,
+    }
 
 
 def _upsert_residence(item: ResidenceIn, *, scraped_at: datetime) -> Residence:

--- a/services/api/scraping/bag_client.py
+++ b/services/api/scraping/bag_client.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Self
+
+import httpx
+
+# Kadaster Individuele Bevragingen v2. The acceptance environment is at
+# api.bag.acceptatie.kadaster.nl — switch via base_url if you need to test
+# against synthetic data without burning prod rate limit quota.
+_BAG_BASE_URL = "https://api.bag.kadaster.nl/lvbag/individuelebevragingen/v2"
+
+
+class BagLookupFailure(StrEnum):
+    MISSING_ADDRESS = "missing_address"
+    NO_MATCH = "no_match"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class BagLookupSuccess:
+    bag_id: str
+    street: str
+    house_number: int
+    house_letter: str | None
+    house_number_suffix: str | None
+    postcode: str
+    city: str
+
+
+BagLookupResult = BagLookupSuccess | BagLookupFailure
+
+
+class BagClient:
+    """Resolves Dutch addresses to BAG records via Kadaster Individuele
+    Bevragingen v2. Use as a context manager so the httpx client closes
+    cleanly after each batch of lookups."""
+
+    def __init__(self, *, api_key: str, base_url: str = _BAG_BASE_URL, timeout: float = 10.0) -> None:
+        self._client = httpx.Client(
+            base_url=base_url,
+            headers={
+                "X-Api-Key": api_key,
+                "Accept": "application/hal+json",
+                "Accept-Crs": "epsg:28992",
+            },
+            timeout=timeout,
+        )
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._client.close()
+
+    def lookup(
+        self,
+        *,
+        postcode: str | None,
+        house_number: int | None,
+        house_letter: str | None = None,
+        house_number_suffix: str | None = None,
+    ) -> BagLookupResult:
+        if not postcode or house_number is None:
+            return BagLookupFailure.MISSING_ADDRESS
+
+        params: dict[str, str | int] = {
+            "postcode": postcode.replace(" ", "").upper(),
+            "huisnummer": house_number,
+        }
+        if house_letter:
+            params["huisletter"] = house_letter
+        if house_number_suffix:
+            params["huisnummertoevoeging"] = house_number_suffix
+
+        response = self._client.get("/adressen", params=params)
+        if response.status_code == 404:
+            return BagLookupFailure.NO_MATCH
+        response.raise_for_status()
+
+        addresses = (response.json().get("_embedded") or {}).get("adressen") or []
+        if not addresses:
+            return BagLookupFailure.NO_MATCH
+        if len(addresses) > 1:
+            return BagLookupFailure.AMBIGUOUS
+
+        address = addresses[0]
+        return BagLookupSuccess(
+            bag_id=address["nummeraanduidingIdentificatie"],
+            street=address["openbareRuimteNaam"],
+            house_number=int(address["huisnummer"]),
+            house_letter=address.get("huisletter"),
+            house_number_suffix=address.get("huisnummertoevoeging"),
+            postcode=address["postcode"],
+            city=address["woonplaatsNaam"],
+        )

--- a/services/api/scraping/schemas.py
+++ b/services/api/scraping/schemas.py
@@ -29,7 +29,9 @@ class ResidenceIn(Schema):
     house_letter: str | None = None
     house_number_suffix: str | None = None
     postcode: str | None = None
-    bag_id: str
+    # Optional: scraper-supplied bag_id is the legacy path; absent/empty
+    # routes the listing through API-side BAG resolution (Celery task).
+    bag_id: str | None = None
     property_type: str | None = None
     bedrooms: int | None = None
     area_sqm: float | None = None

--- a/services/api/scraping/tasks.py
+++ b/services/api/scraping/tasks.py
@@ -6,9 +6,20 @@ from django.conf import settings
 from django.utils import timezone
 from loguru import logger
 
+from scraping.bag_client import BagClient, BagLookupFailure, BagLookupSuccess
 from scraping.cleanup import delete_expired_terminal_residences
-from scraping.models import Website
+from scraping.models import BagStatus, Listing, Residence, Website
+from scraping.reconciliation import reconcile_residence
 from scraping.schemas import ScrapeDispatchPayload
+
+# BagLookupFailure → BagStatus. The client's MISSING_ADDRESS short-circuits
+# before any HTTP call (postcode/house_number missing); NO_MATCH and
+# AMBIGUOUS come back from the API.
+_FAILURE_TO_BAG_STATUS = {
+    BagLookupFailure.MISSING_ADDRESS: BagStatus.MISSING_ADDRESS,
+    BagLookupFailure.NO_MATCH: BagStatus.BAG_NO_MATCH,
+    BagLookupFailure.AMBIGUOUS: BagStatus.BAG_AMBIGUOUS,
+}
 
 
 @shared_task(name="scraping.ping")
@@ -60,3 +71,68 @@ def cleanup_expired_residences() -> int:
     """Hard-delete residences that have been in a terminal status (sold or
     sale_pending) past the TTL. Schedule via a PeriodicTask in Django admin."""
     return delete_expired_terminal_residences(now=timezone.now())
+
+
+@shared_task(
+    name="scraping.resolve_bag",
+    autoretry_for=(httpx.HTTPError,),
+    retry_backoff=True,
+    retry_backoff_max=300,
+    max_retries=5,
+    rate_limit="5/s",
+)
+def resolve_bag(listing_id: int) -> None:
+    """Resolve a Listing's raw address bits to a BAG-canonical Residence.
+
+    Idempotent: re-runs are safe and skip listings that have already
+    transitioned out of `pending`. HTTPError raises for Celery retry; any
+    terminal BAG outcome (no-match / ambiguous / missing-address) writes
+    `bag_status` and `bag_failure_reason` and returns without retrying."""
+    listing = Listing.objects.filter(pk=listing_id).first()
+    if listing is None or listing.bag_status != BagStatus.PENDING:
+        return
+
+    with BagClient(api_key=settings.BAG_API_KEY) as client:
+        result = client.lookup(
+            postcode=listing.postcode,
+            house_number=listing.house_number,
+            house_letter=listing.house_letter,
+            house_number_suffix=listing.house_number_suffix,
+        )
+
+    if isinstance(result, BagLookupSuccess):
+        residence, _ = Residence.objects.get_or_create(
+            bag_id=result.bag_id,
+            defaults=_residence_defaults_from_lookup(result, listing),
+        )
+        listing.residence = residence
+        listing.bag_status = BagStatus.RESOLVED
+        listing.bag_resolved_at = timezone.now()
+        listing.save(update_fields=["residence", "bag_status", "bag_resolved_at"])
+        reconcile_residence(residence)
+        return
+
+    listing.bag_status = _FAILURE_TO_BAG_STATUS[result]
+    listing.bag_failure_reason = f"BAG lookup: {result.value}"
+    listing.save(update_fields=["bag_status", "bag_failure_reason"])
+
+
+def _residence_defaults_from_lookup(result: BagLookupSuccess, listing: Listing) -> dict:
+    now = timezone.now()
+    return {
+        "title": listing.title or "",
+        "price": listing.price or "",
+        "price_eur": listing.price_eur,
+        "city": result.city,
+        "street": result.street,
+        "house_number": result.house_number,
+        "house_letter": result.house_letter,
+        "house_number_suffix": result.house_number_suffix,
+        "postcode": result.postcode,
+        "image_url": listing.image_url,
+        "status": listing.status,
+        "status_changed_at": now,
+        "scraped_at": listing.scraped_at or now,
+        "current_status": listing.status,
+        "last_scraped_at": listing.scraped_at,
+    }

--- a/services/api/tests/test_bag_client.py
+++ b/services/api/tests/test_bag_client.py
@@ -1,0 +1,149 @@
+import httpx
+import pytest
+import respx
+
+from scraping.bag_client import BagClient, BagLookupFailure, BagLookupSuccess
+
+_TEST_BASE_URL = "https://bag.test/v2"
+
+
+def _client() -> BagClient:
+    return BagClient(api_key="test-key", base_url=_TEST_BASE_URL)
+
+
+def _address(**overrides) -> dict:
+    base = {
+        "openbareRuimteNaam": "Klaterweg",
+        "huisnummer": 9,
+        "huisletter": "R",
+        "huisnummertoevoeging": "A59",
+        "postcode": "1271KE",
+        "woonplaatsNaam": "Huizen",
+        "nummeraanduidingIdentificatie": "0402200000084467",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_lookup_returns_missing_address_when_postcode_blank():
+    with _client() as client:
+        result = client.lookup(postcode=None, house_number=9)
+    assert result is BagLookupFailure.MISSING_ADDRESS
+
+
+def test_lookup_returns_missing_address_when_house_number_none():
+    with _client() as client:
+        result = client.lookup(postcode="1271 KE", house_number=None)
+    assert result is BagLookupFailure.MISSING_ADDRESS
+
+
+@respx.mock
+def test_lookup_success_returns_canonical_record():
+    respx.get(f"{_TEST_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_address()]}})
+    )
+
+    with _client() as client:
+        result = client.lookup(postcode="1271 KE", house_number=9, house_letter="R", house_number_suffix="A59")
+
+    assert isinstance(result, BagLookupSuccess)
+    assert result.bag_id == "0402200000084467"
+    assert result.street == "Klaterweg"
+    assert result.house_number == 9
+    assert result.house_letter == "R"
+    assert result.house_number_suffix == "A59"
+    assert result.postcode == "1271KE"
+    assert result.city == "Huizen"
+
+
+@respx.mock
+def test_lookup_strips_postcode_whitespace_and_passes_optional_params():
+    route = respx.get(f"{_TEST_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_address()]}})
+    )
+
+    with _client() as client:
+        client.lookup(postcode="1271 ke", house_number=9, house_letter="R", house_number_suffix="A59")
+
+    sent = route.calls.last.request.url.params
+    assert sent["postcode"] == "1271KE"
+    assert sent["huisnummer"] == "9"
+    assert sent["huisletter"] == "R"
+    assert sent["huisnummertoevoeging"] == "A59"
+
+
+@respx.mock
+def test_lookup_omits_optional_params_when_blank():
+    route = respx.get(f"{_TEST_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_address(huisletter=None)]}})
+    )
+
+    with _client() as client:
+        client.lookup(postcode="1271KE", house_number=9)
+
+    sent = route.calls.last.request.url.params
+    assert "huisletter" not in sent
+    assert "huisnummertoevoeging" not in sent
+
+
+@respx.mock
+def test_lookup_returns_no_match_on_empty_embedded():
+    respx.get(f"{_TEST_BASE_URL}/adressen").mock(return_value=httpx.Response(200, json={"_embedded": {"adressen": []}}))
+
+    with _client() as client:
+        result = client.lookup(postcode="9999XX", house_number=1)
+
+    assert result is BagLookupFailure.NO_MATCH
+
+
+@respx.mock
+def test_lookup_returns_no_match_on_404():
+    respx.get(f"{_TEST_BASE_URL}/adressen").mock(return_value=httpx.Response(404, json={"detail": "not found"}))
+
+    with _client() as client:
+        result = client.lookup(postcode="9999XX", house_number=1)
+
+    assert result is BagLookupFailure.NO_MATCH
+
+
+@respx.mock
+def test_lookup_returns_ambiguous_when_multiple_results():
+    respx.get(f"{_TEST_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "_embedded": {
+                    "adressen": [
+                        _address(nummeraanduidingIdentificatie="0402200000000001"),
+                        _address(nummeraanduidingIdentificatie="0402200000000002"),
+                    ]
+                }
+            },
+        )
+    )
+
+    with _client() as client:
+        result = client.lookup(postcode="1271KE", house_number=9)
+
+    assert result is BagLookupFailure.AMBIGUOUS
+
+
+@respx.mock
+def test_lookup_propagates_5xx_for_celery_retry():
+    respx.get(f"{_TEST_BASE_URL}/adressen").mock(return_value=httpx.Response(503))
+
+    with _client() as client, pytest.raises(httpx.HTTPStatusError):
+        client.lookup(postcode="1271KE", house_number=9)
+
+
+@respx.mock
+def test_lookup_sends_api_key_header():
+    route = respx.get(f"{_TEST_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_address()]}})
+    )
+
+    with _client() as client:
+        client.lookup(postcode="1271KE", house_number=9)
+
+    assert route.calls.last.request.headers["X-Api-Key"] == "test-key"
+    assert route.calls.last.request.headers["Accept"] == "application/hal+json"

--- a/services/api/tests/test_internal.py
+++ b/services/api/tests/test_internal.py
@@ -1,7 +1,10 @@
 from datetime import UTC, datetime, timedelta
 from typing import cast
+from unittest import mock
 
+import httpx
 import pytest
+import respx
 from scraping.models import (
     BagStatus,
     DeadResidence,
@@ -374,8 +377,123 @@ def test_submit_results_rejects_inverted_timestamps(client, api_key_headers, scr
     assert response.status_code == 422
 
 
-def test_submit_results_rejects_residence_without_bag_id(client, api_key_headers, scrape_payload, residence_payload):
+def test_submit_results_accepts_payload_without_bag_id_and_queues_resolution(
+    client, api_key_headers, scrape_payload, residence_payload
+):
+    """The post-PR-4 scraper drops scraper-side BAG enrichment and submits raw
+    listings. The handler stores them as `bag_status='pending'` with no
+    Residence link and queues `resolve_bag` to do the lookup async.
+
+    `transaction.on_commit` is patched to fire the callback inline because
+    pytest-django wraps each test in a transaction that's rolled back, so
+    real on-commit callbacks never run."""
     item = residence_payload()
+    del item["bag_id"]
+    payload = scrape_payload(listings=[item])
+
+    with (
+        mock.patch("scraping.api.transaction.on_commit", side_effect=lambda fn: fn()),
+        mock.patch("scraping.api.resolve_bag.delay") as task_delay,
+    ):
+        response = client.post(
+            f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["new_listings_count"] == 1
+    assert Residence.objects.count() == 0
+    listing = Listing.objects.get(url=item["detail_url"])
+    assert listing.bag_status == BagStatus.PENDING
+    assert listing.residence is None
+    assert listing.title == item["title"]
+    assert listing.price == item["price"]
+    task_delay.assert_called_once_with(listing.pk)
+
+
+def test_submit_results_treats_empty_string_bag_id_as_missing(
+    client, api_key_headers, scrape_payload, residence_payload
+):
+    payload = scrape_payload(listings=[residence_payload(bag_id="")])
+
+    with (
+        mock.patch("scraping.api.transaction.on_commit", side_effect=lambda fn: fn()),
+        mock.patch("scraping.api.resolve_bag.delay") as task_delay,
+    ):
+        response = client.post(
+            f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
+        )
+
+    assert response.status_code == 200
+    listing = Listing.objects.get()
+    assert listing.bag_status == BagStatus.PENDING
+    task_delay.assert_called_once_with(listing.pk)
+
+
+def test_submit_results_does_not_redispatch_for_already_resolved_url(
+    client, api_key_headers, scrape_payload, residence_payload
+):
+    """Re-scrape of the same URL shouldn't re-queue resolution — the listing
+    is already linked to a residence; the bag_status guard preserves it."""
+    existing_residence = cast(Residence, ResidenceFactory(bag_id="0003200000000900"))
+    ListingFactory(
+        residence=existing_residence,
+        url="https://funda.nl/listing/already-resolved",
+        bag_status=BagStatus.RESOLVED,
+    )
+    item = residence_payload(detail_url="https://funda.nl/listing/already-resolved")
+    del item["bag_id"]
+    payload = scrape_payload(listings=[item])
+
+    with mock.patch("scraping.api.resolve_bag.delay") as task_delay:
+        response = client.post(
+            f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
+        )
+
+    assert response.status_code == 200
+    task_delay.assert_not_called()
+    listing = Listing.objects.get(url="https://funda.nl/listing/already-resolved")
+    assert listing.bag_status == BagStatus.RESOLVED
+    assert listing.residence == existing_residence
+
+
+@pytest.mark.django_db(transaction=True)
+@respx.mock
+def test_submit_results_no_bag_id_path_resolves_end_to_end(client, api_key_headers, scrape_payload, residence_payload):
+    """End-to-end: POST → on_commit fires resolve_bag → BAG mocked → listing
+    lands as RESOLVED with a Residence linked. `transaction=True` is needed
+    so `transaction.on_commit` callbacks actually fire (the default
+    non-transactional pytest-django marker swallows them)."""
+    from scraping.bag_client import _BAG_BASE_URL
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "_embedded": {
+                    "adressen": [
+                        {
+                            "openbareRuimteNaam": "Klaterweg",
+                            "huisnummer": 9,
+                            "huisletter": "R",
+                            "huisnummertoevoeging": "A59",
+                            "postcode": "1271KE",
+                            "woonplaatsNaam": "Huizen",
+                            "nummeraanduidingIdentificatie": "0402200000084467",
+                        }
+                    ]
+                }
+            },
+        )
+    )
+    item = residence_payload(
+        detail_url="https://funda.nl/listing/e2e",
+        postcode="1271 KE",
+        house_number=9,
+        house_letter="R",
+        house_number_suffix="A59",
+        city="Huizen",
+    )
     del item["bag_id"]
     payload = scrape_payload(listings=[item])
 
@@ -383,9 +501,11 @@ def test_submit_results_rejects_residence_without_bag_id(client, api_key_headers
         f"/internal/v1/scrape-runs/{Website.FUNDA.value}/results", json=payload, headers=api_key_headers
     )
 
-    assert response.status_code == 422
-    assert "bag_id" in response.content.decode()
-    assert Residence.objects.count() == 0
+    assert response.status_code == 200
+    listing = Listing.objects.get(url="https://funda.nl/listing/e2e")
+    assert listing.bag_status == BagStatus.RESOLVED
+    assert listing.residence is not None
+    assert listing.residence.bag_id == "0402200000084467"
 
 
 @pytest.mark.parametrize(

--- a/services/api/tests/test_tasks.py
+++ b/services/api/tests/test_tasks.py
@@ -1,6 +1,12 @@
+from typing import cast
+
 import httpx
 import pytest
 import respx
+
+from scraping.bag_client import _BAG_BASE_URL
+from scraping.models import BagStatus, Listing, ListingStatus, Residence
+from tests.factories import ListingFactory, ResidenceFactory
 
 
 def test_ping_returns_pong_under_eager_mode():
@@ -56,3 +62,179 @@ def test_dispatch_scrape_rejects_unknown_website(settings):
 
     with pytest.raises(ValueError):
         dispatch_scrape.delay("not-a-real-site").get(timeout=1)
+
+
+def _bag_address(**overrides) -> dict:
+    base = {
+        "openbareRuimteNaam": "Klaterweg",
+        "huisnummer": 9,
+        "huisletter": "R",
+        "huisnummertoevoeging": "A59",
+        "postcode": "1271KE",
+        "woonplaatsNaam": "Huizen",
+        "nummeraanduidingIdentificatie": "0402200000084467",
+    }
+    base.update(overrides)
+    return base
+
+
+def _pending_listing(**overrides) -> Listing:
+    defaults: dict = {
+        "residence": None,
+        "bag_status": BagStatus.PENDING,
+        "title": "Sunny duplex",
+        "price": "€ 425.000 k.k.",
+        "price_eur": 425_000,
+        "image_url": "https://cdn.example.com/abc.jpg",
+        "status": ListingStatus.NEW,
+        "postcode": "1271 KE",
+        "house_number": 9,
+        "house_letter": "R",
+        "house_number_suffix": "A59",
+        "city": "Huizen",
+    }
+    defaults.update(overrides)
+    return cast(Listing, ListingFactory(**defaults))
+
+
+@pytest.mark.django_db
+@respx.mock
+def test_resolve_bag_links_listing_to_residence_and_reconciles():
+    from scraping.tasks import resolve_bag
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_bag_address()]}})
+    )
+    listing = _pending_listing()
+
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.RESOLVED
+    assert listing.bag_resolved_at is not None
+    assert listing.residence is not None
+    assert listing.residence.bag_id == "0402200000084467"
+    assert listing.residence.street == "Klaterweg"
+    assert listing.residence.city == "Huizen"
+    assert listing.residence.current_price_eur == 425_000
+    assert listing.residence.current_status == ListingStatus.NEW
+
+
+@pytest.mark.django_db
+@respx.mock
+def test_resolve_bag_attaches_to_existing_residence_for_cross_portal():
+    from scraping.tasks import resolve_bag
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(200, json={"_embedded": {"adressen": [_bag_address()]}})
+    )
+    existing = cast(Residence, ResidenceFactory(bag_id="0402200000084467", price_eur=520_000))
+    listing = _pending_listing(price_eur=480_000)
+
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.residence == existing
+    existing.refresh_from_db()
+    assert existing.current_price_eur == 480_000  # min across resolved listings
+
+
+@pytest.mark.django_db
+@respx.mock
+def test_resolve_bag_marks_no_match_when_bag_returns_empty():
+    from scraping.tasks import resolve_bag
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(return_value=httpx.Response(200, json={"_embedded": {"adressen": []}}))
+    listing = _pending_listing()
+
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.BAG_NO_MATCH
+    assert listing.residence is None
+    assert listing.bag_failure_reason is not None
+    assert "no_match" in listing.bag_failure_reason
+
+
+@pytest.mark.django_db
+@respx.mock
+def test_resolve_bag_marks_ambiguous_when_bag_returns_multiple():
+    from scraping.tasks import resolve_bag
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "_embedded": {
+                    "adressen": [
+                        _bag_address(nummeraanduidingIdentificatie="0402200000000001"),
+                        _bag_address(nummeraanduidingIdentificatie="0402200000000002"),
+                    ]
+                }
+            },
+        )
+    )
+    listing = _pending_listing()
+
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.BAG_AMBIGUOUS
+    assert listing.residence is None
+
+
+@pytest.mark.django_db
+def test_resolve_bag_marks_missing_address_when_postcode_blank():
+    from scraping.tasks import resolve_bag
+
+    listing = _pending_listing(postcode=None)
+
+    # No respx mock — task must short-circuit before any HTTP call.
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.MISSING_ADDRESS
+    assert listing.residence is None
+
+
+@pytest.mark.django_db
+def test_resolve_bag_is_idempotent_on_already_resolved_listing():
+    from scraping.tasks import resolve_bag
+
+    residence = cast(Residence, ResidenceFactory())
+    listing = cast(
+        Listing,
+        ListingFactory(
+            residence=residence,
+            bag_status=BagStatus.RESOLVED,
+            postcode="1271 KE",
+            house_number=9,
+        ),
+    )
+
+    # No respx mock — already-resolved listings must not hit BAG.
+    resolve_bag.delay(listing.pk).get(timeout=1)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.RESOLVED
+    assert listing.residence == residence
+
+
+@pytest.mark.django_db
+@respx.mock
+def test_resolve_bag_propagates_5xx_so_celery_retries():
+    """Bypass the @shared_task wrapper to check the underlying function raises
+    HTTPStatusError on 5xx. The decorator's `autoretry_for=(httpx.HTTPError,)`
+    + `retry_backoff=True` (covered by the task definition itself, not this
+    test) handles the retry — we just need to be sure we don't swallow the
+    error and leave the listing terminally stuck."""
+    from scraping.tasks import resolve_bag
+
+    respx.get(f"{_BAG_BASE_URL}/adressen").mock(return_value=httpx.Response(503))
+    listing = _pending_listing()
+
+    with pytest.raises(httpx.HTTPStatusError):
+        resolve_bag(listing.pk)
+
+    listing.refresh_from_db()
+    assert listing.bag_status == BagStatus.PENDING


### PR DESCRIPTION
## Summary

PR 3 of 5 in the listing-source-of-truth migration. Moves BAG enrichment from the scraper into the API behind a Celery task. **Backwards-compatible**: today's scraper still ships `bag_id` and stays on the legacy fast path; a future scraper without scraper-side BAG (PR 4) will submit listings with `bag_id` absent and let the task resolve.

Previous: [PR 1 #128](https://github.com/DiegoHeer/realty-alerts/pull/128) (per-portal columns + reconciliation), [PR 2 #129](https://github.com/DiegoHeer/realty-alerts/pull/129) (read pivot to current_*).

### Commit-by-commit

1. **`feat(api): add BAG_API_KEY env var for Kadaster API access`** — required env var following the existing `REALTY_API_KEY` pattern. Local dev gets a stub via `os.environ.setdefault`; CI test workflow sets `BAG_API_KEY=test-bag-key`.

2. **`feat(api): add BagClient for Kadaster Individuele Bevragingen v2`** — pure HTTP wrapper, no callers yet. Context manager (`__enter__`/`__exit__`). Returns `BagLookupSuccess` or one of `BagLookupFailure.{MISSING_ADDRESS, NO_MATCH, AMBIGUOUS}`. 5xx propagates `httpx.HTTPStatusError` for the next commit's task to retry.

3. **`feat(api): add resolve_bag Celery task for async BAG resolution`** — `autoretry_for=(httpx.HTTPError,)`, `retry_backoff=True`, `retry_backoff_max=300`, `max_retries=5`, `rate_limit="5/s"`. Idempotent (skips non-`PENDING` listings). On success: `Residence.objects.get_or_create(bag_id=…)` (cross-portal collapse), links the listing, calls `reconcile_residence`. Still no callers in this commit.

4. **`feat(api): accept scrape payloads without bag_id and queue resolution`** — handler routes by `bag_id` presence. New path stores Listings as `bag_status='pending'` and queues the task via `transaction.on_commit` so a rolled-back ingest doesn't fire orphan jobs. Re-scrape of an already-resolved URL preserves the FK and bag_status.

### Migration / deployment notes

- **`BAG_API_KEY` must be set in production** — `realty-ai-platform`'s API deployment needs the secret added before this rolls out, otherwise Django settings fail to import on boot.
- The BAG base URL is hardcoded to `https://api.bag.kadaster.nl/lvbag/individuelebevragingen/v2`. To target the acceptance environment for staging, override at the call site (the constructor takes `base_url`).

## Test plan

- [x] `make test` — 106 green (api 86 → 106; +10 BagClient unit tests, +7 task tests, +3 net integration tests).
- [x] `pre-commit run --all-files` — all hooks pass with the bumped ruff rev (#130).
- [x] `ty check` — clean (only the 2 pre-existing migration-comment warnings inherited from `main`).
- [ ] Manual: confirm the secret is set in `realty-ai-platform` before the image is bumped to this branch.
- [ ] Manual: deploy to dev, send a synthetic POST without `bag_id`, watch a Celery worker log the `scraping.resolve_bag` task and the resulting Listing transition `pending → resolved` with a linked Residence in `/admin`.
- [ ] Manual: send a synthetic payload with a postcode that doesn't exist in BAG, confirm the listing lands as `bag_status='bag_no_match'` and `bag_failure_reason` is populated.